### PR TITLE
Implement slot sharing support

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotSharingGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotSharingGroup.java
@@ -25,7 +25,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /** Represents execution vertices that will run the same shared slot. */
-class ExecutionSlotSharingGroup {
+public class ExecutionSlotSharingGroup {
 
     private final Set<ExecutionVertexID> executionVertexIds;
 
@@ -39,5 +39,14 @@ class ExecutionSlotSharingGroup {
 
     Set<ExecutionVertexID> getExecutionVertexIds() {
         return Collections.unmodifiableSet(executionVertexIds);
+    }
+
+    public static ExecutionSlotSharingGroup forVertexIds(
+            Set<ExecutionVertexID> executionVertexIds) {
+        final ExecutionSlotSharingGroup executionSlotSharingGroup = new ExecutionSlotSharingGroup();
+        for (ExecutionVertexID executionVertexId : executionVertexIds) {
+            executionSlotSharingGroup.addVertex(executionVertexId);
+        }
+        return executionSlotSharingGroup;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SharedSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SharedSlot.java
@@ -62,7 +62,7 @@ import java.util.stream.Collectors;
  * {@link SlotSharingExecutionSlotAllocator} to remove it from the allocator and cancel its
  * underlying physical slot request if the request is not fulfilled yet.
  */
-class SharedSlot implements SlotOwner, PhysicalSlot.Payload {
+public class SharedSlot implements SlotOwner, PhysicalSlot.Payload {
     private static final Logger LOG = LoggerFactory.getLogger(SharedSlot.class);
 
     private final SlotRequestId physicalSlotRequestId;
@@ -83,7 +83,7 @@ class SharedSlot implements SlotOwner, PhysicalSlot.Payload {
 
     private State state;
 
-    SharedSlot(
+    public SharedSlot(
             SlotRequestId physicalSlotRequestId,
             ResourceProfile physicalSlotResourceProfile,
             ExecutionSlotSharingGroup executionSlotSharingGroup,
@@ -134,7 +134,7 @@ class SharedSlot implements SlotOwner, PhysicalSlot.Payload {
      *     logical slot
      * @return the logical slot future
      */
-    CompletableFuture<LogicalSlot> allocateLogicalSlot(ExecutionVertexID executionVertexId) {
+    public CompletableFuture<LogicalSlot> allocateLogicalSlot(ExecutionVertexID executionVertexId) {
         Preconditions.checkArgument(
                 executionSlotSharingGroup.getExecutionVertexIds().contains(executionVertexId),
                 "Trying to allocate a logical slot for execution %s which is not in the ExecutionSlotSharingGroup",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/SharedSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/SharedSlot.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.jobmanager.scheduler.Locality;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotOwner;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlot;
+import org.apache.flink.runtime.jobmaster.slotpool.SingleLogicalSlot;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Shared slot implementation for the {@link DeclarativeScheduler}. */
+public class SharedSlot implements SlotOwner, PhysicalSlot.Payload {
+    private static final Logger LOG = LoggerFactory.getLogger(SharedSlot.class);
+
+    private final SlotRequestId physicalSlotRequestId;
+
+    private final PhysicalSlot physicalSlot;
+
+    private final Runnable externalReleaseCallback;
+
+    private final Map<SlotRequestId, LogicalSlot> allocatedLogicalSlots;
+
+    private final boolean slotWillBeOccupiedIndefinitely;
+
+    private State state;
+
+    public SharedSlot(
+            SlotRequestId physicalSlotRequestId,
+            PhysicalSlot physicalSlot,
+            boolean slotWillBeOccupiedIndefinitely,
+            Runnable externalReleaseCallback) {
+        this.physicalSlotRequestId = physicalSlotRequestId;
+        this.physicalSlot = physicalSlot;
+        this.slotWillBeOccupiedIndefinitely = slotWillBeOccupiedIndefinitely;
+        this.externalReleaseCallback = externalReleaseCallback;
+        this.state = State.ALLOCATED;
+        this.allocatedLogicalSlots = new HashMap<>();
+        physicalSlot.tryAssignPayload(this);
+    }
+
+    /**
+     * Registers an allocation request for a logical slot.
+     *
+     * <p>The logical slot request is complete once the underlying physical slot request is
+     * complete.
+     *
+     * @return the logical slot
+     */
+    public LogicalSlot allocateLogicalSlot() {
+        LOG.debug("Allocating logical slot from shared slot ({})", physicalSlotRequestId);
+        return new SingleLogicalSlot(
+                new SlotRequestId(),
+                physicalSlot,
+                null,
+                Locality.UNKNOWN,
+                this,
+                slotWillBeOccupiedIndefinitely);
+    }
+
+    @Override
+    public void returnLogicalSlot(LogicalSlot logicalSlot) {
+        LOG.debug("Returning logical slot to shared slot ({})", physicalSlotRequestId);
+        Preconditions.checkState(
+                allocatedLogicalSlots.remove(logicalSlot.getSlotRequestId()) != null,
+                "Trying to remove a logical slot request which has been either already removed or never created.");
+        tryReleaseExternally();
+    }
+
+    @Override
+    public void release(Throwable cause) {
+        LOG.debug("Release shared slot ({})", physicalSlotRequestId);
+
+        // copy the logical slot collection to avoid ConcurrentModificationException
+        // if logical slot releases cause cancellation of other executions
+        // which will try to call returnLogicalSlot and modify requestedLogicalSlots collection
+        final List<LogicalSlot> collect = new ArrayList<>(allocatedLogicalSlots.values());
+        for (LogicalSlot allocatedLogicalSlot : collect) {
+            allocatedLogicalSlot.releaseSlot(cause);
+        }
+        allocatedLogicalSlots.clear();
+        tryReleaseExternally();
+    }
+
+    private void tryReleaseExternally() {
+        if (state != State.RELEASED && allocatedLogicalSlots.isEmpty()) {
+            state = State.RELEASED;
+            LOG.debug("Release shared slot externally ({})", physicalSlotRequestId);
+            externalReleaseCallback.run();
+        }
+    }
+
+    @Override
+    public boolean willOccupySlotIndefinitely() {
+        return slotWillBeOccupiedIndefinitely;
+    }
+
+    private enum State {
+        ALLOCATED,
+        RELEASED
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSlotSharingITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSlotSharingITCase.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.dispatcher.SchedulerNGFactoryFactory;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.runtime.testutils.MiniClusterResource;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/** SlotSharing tests for the {@link DeclarativeScheduler}. */
+public class DeclarativeSchedulerSlotSharingITCase extends TestLogger {
+
+    private static final int NUMBER_TASK_MANAGERS = 1;
+    private static final int NUMBER_SLOTS_PER_TASK_MANAGER = 1;
+    private static final int PARALLELISM = 10;
+
+    private static Configuration getConfiguration() {
+        final Configuration configuration = new Configuration();
+
+        configuration.set(
+                JobManagerOptions.SCHEDULER, SchedulerNGFactoryFactory.DECLARATIVE_SCHEDULER);
+        configuration.set(ClusterOptions.ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT, true);
+
+        return configuration;
+    }
+
+    @ClassRule
+    public static final MiniClusterResource MINI_CLUSTER_RESOURCE =
+            new MiniClusterResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setConfiguration(getConfiguration())
+                            .setNumberTaskManagers(NUMBER_TASK_MANAGERS)
+                            .setNumberSlotsPerTaskManager(NUMBER_SLOTS_PER_TASK_MANAGER)
+                            .build());
+
+    @Test
+    public void testSchedulingOfJobRequiringSlotSharing() throws Exception {
+        // run job multiple times to ensure slots are cleaned up properly
+        runJob();
+        runJob();
+    }
+
+    private void runJob() throws Exception {
+        final MiniCluster miniCluster = MINI_CLUSTER_RESOURCE.getMiniCluster();
+        final JobGraph jobGraph = createJobGraph();
+
+        miniCluster.submitJob(jobGraph).join();
+
+        final JobResult jobResult = miniCluster.requestJobResult(jobGraph.getJobID()).join();
+
+        // this throws an exception if the job failed
+        jobResult.toJobExecutionResult(getClass().getClassLoader());
+
+        assertTrue(jobResult.isSuccess());
+    }
+
+    /**
+     * Returns a JobGraph that requires slot sharing to work in order to be able to run with a
+     * single slot.
+     */
+    private static JobGraph createJobGraph() {
+        final SlotSharingGroup slotSharingGroup = new SlotSharingGroup();
+
+        final JobVertex source = new JobVertex("Source");
+        source.setInvokableClass(NoOpInvokable.class);
+        source.setParallelism(PARALLELISM);
+        source.setSlotSharingGroup(slotSharingGroup);
+
+        final JobVertex sink = new JobVertex("sink");
+        sink.setInvokableClass(NoOpInvokable.class);
+        sink.setParallelism(PARALLELISM);
+        sink.setSlotSharingGroup(slotSharingGroup);
+
+        sink.connectNewDataSetAsInput(
+                source, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
+
+        return new JobGraph("Simple job", source, sink);
+    }
+}


### PR DESCRIPTION
This PR implements slot sharing, which at the very least should _work_.

The core logic is remarkable similar to how vertices were handled so far.

To compute the requirements we no longer use the summed parallelism over all vertices, but instead the summed max parallelism of all slot sharing groups,
Free slots are not distributed over vertices, but slot sharing groups.
The vertex parallelism is then determined within the SlotSharingGroup; it is either the number of slots the group has been provided with or the vertex parallelism, whichever is slower.

Once we have the parallelism we can generate the ExecutionVertexIds, reserve all the slots we received, wrap them in a SharedSlot, and then allocated the logical slots from it.

The contained test run a job with 2 vertices with a pipelined data exchange within a single SlotSharingGroup, on a cluster with only 1 slot total. The job is run twice to make sure the slot release works properly.

The following things are not explicitly handled:
- CoLocation constraints: As it is, given N vertices in one slot sharing group the i-th subtask of each are deployed into the same slot, which seems to fulfill the core requirement? What I'm not sure about is whether the scheduler is responsible for matching the parallelism, or whether the JobGraphGenerator handles this earlier.
- Input Locality: Not relevant for streaming?
- Prior Locations: If we want to account for this when re-scaling then we'll need some data-structure outside the EG that tells us where we deployed things on a previous run, or keep the old EG around.

Re existing classes: The `SlotSharingExecutionSlotAllocator` was a somewhat good guide on what is needed, but it is really setup for asynchronous operations which we don't really need currently.