### PR TITLE
Requirement mapping component

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotSharingGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotSharingGroup.java
@@ -25,7 +25,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /** Represents execution vertices that will run the same shared slot. */
-class ExecutionSlotSharingGroup {
+public class ExecutionSlotSharingGroup {
 
     private final Set<ExecutionVertexID> executionVertexIds;
 
@@ -39,5 +39,14 @@ class ExecutionSlotSharingGroup {
 
     Set<ExecutionVertexID> getExecutionVertexIds() {
         return Collections.unmodifiableSet(executionVertexIds);
+    }
+
+    public static ExecutionSlotSharingGroup forVertexIds(
+            Set<ExecutionVertexID> executionVertexIds) {
+        final ExecutionSlotSharingGroup executionSlotSharingGroup = new ExecutionSlotSharingGroup();
+        for (ExecutionVertexID executionVertexId : executionVertexIds) {
+            executionSlotSharingGroup.addVertex(executionVertexId);
+        }
+        return executionSlotSharingGroup;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SharedSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SharedSlot.java
@@ -62,7 +62,7 @@ import java.util.stream.Collectors;
  * {@link SlotSharingExecutionSlotAllocator} to remove it from the allocator and cancel its
  * underlying physical slot request if the request is not fulfilled yet.
  */
-class SharedSlot implements SlotOwner, PhysicalSlot.Payload {
+public class SharedSlot implements SlotOwner, PhysicalSlot.Payload {
     private static final Logger LOG = LoggerFactory.getLogger(SharedSlot.class);
 
     private final SlotRequestId physicalSlotRequestId;
@@ -83,7 +83,7 @@ class SharedSlot implements SlotOwner, PhysicalSlot.Payload {
 
     private State state;
 
-    SharedSlot(
+    public SharedSlot(
             SlotRequestId physicalSlotRequestId,
             ResourceProfile physicalSlotResourceProfile,
             ExecutionSlotSharingGroup executionSlotSharingGroup,
@@ -134,7 +134,7 @@ class SharedSlot implements SlotOwner, PhysicalSlot.Payload {
      *     logical slot
      * @return the logical slot future
      */
-    CompletableFuture<LogicalSlot> allocateLogicalSlot(ExecutionVertexID executionVertexId) {
+    public CompletableFuture<LogicalSlot> allocateLogicalSlot(ExecutionVertexID executionVertexId) {
         Preconditions.checkArgument(
                 executionSlotSharingGroup.getExecutionVertexIds().contains(executionVertexId),
                 "Trying to allocate a logical slot for execution %s which is not in the ExecutionSlotSharingGroup",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
@@ -480,7 +480,7 @@ public class DeclarativeScheduler implements SchedulerNG {
                                 new JobGraphJobInformation(jobGraph),
                                 declarativeSlotPool.getFreeSlotsInformation());
 
-        if (slotSharingSlotAssignmentsOptional.isEmpty()) {
+        if (!slotSharingSlotAssignmentsOptional.isPresent()) {
             throw new JobExecutionException(
                     jobGraph.getJobID(), "Not enough resources available for scheduling.");
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -59,7 +60,6 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
-import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTrackerDeploymentListenerAdapter;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
@@ -69,7 +69,6 @@ import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPool;
 import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.ResourceCounter;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
 import org.apache.flink.runtime.jobmaster.slotpool.ThrowingSlotProvider;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
@@ -104,10 +103,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -154,6 +151,9 @@ public class DeclarativeScheduler implements SchedulerNG {
     private long stateVersioner = 0;
 
     private ResourceCounter desiredResources = ResourceCounter.empty();
+
+    private final RequirementsCalculator requirementsCalculator;
+    private final MappingCalculator mappingCalculator;
 
     @Nullable private ExecutionGraph executionGraph = null;
 
@@ -202,6 +202,8 @@ public class DeclarativeScheduler implements SchedulerNG {
         this.checkpointsCleaner = new CheckpointsCleaner();
 
         this.declarativeSlotPool.registerNewSlotsListener(ignored -> newResourcesAvailable());
+        this.requirementsCalculator = new SlotSharingRequirementsCalculator();
+        this.mappingCalculator = new SlotSharingMappingCalculator();
     }
 
     @Override
@@ -469,65 +471,57 @@ public class DeclarativeScheduler implements SchedulerNG {
     }
 
     private ParallelismAndResourceAssignments determineParallelismAndAssignResources(
-            JobGraph jobGraph) {
+            JobGraph jobGraph) throws JobExecutionException {
         final HashMap<ExecutionVertexID, LogicalSlot> assignedSlots = new HashMap<>();
-        final HashMap<JobVertexID, Integer> parallelismPerJobVertex = new HashMap<>();
 
-        final Collection<SlotInfoWithUtilization> freeSlots =
-                declarativeSlotPool.getFreeSlotsInformation();
-        // TODO: This can waste slots if the max parallelism for slot sharing groups is not equal
-        final int slotsPerSlotSharingGroup =
-                freeSlots.size() / jobGraph.getSlotSharingGroups().size();
-        final Iterator<SlotInfoWithUtilization> slotIterator = freeSlots.iterator();
+        final Optional<Map<SlotSharingGroupId, Map<SlotInfo, ExecutionSlotSharingGroup>>>
+                slotSharingSlotAssignmentsOptional =
+                        mappingCalculator.determineParallelismAndAssignResources(
+                                new JobGraphJobInformation(jobGraph),
+                                declarativeSlotPool.getFreeSlotsInformation());
 
-        for (SlotSharingGroup slotSharingGroup : jobGraph.getSlotSharingGroups()) {
-            final List<JobVertex> containedJobVertices =
-                    slotSharingGroup.getJobVertexIds().stream()
-                            .map(jobGraph::findVertexByID)
-                            .collect(Collectors.toList());
+        if (slotSharingSlotAssignmentsOptional.isEmpty()) {
+            throw new JobExecutionException(
+                    jobGraph.getJobID(), "Not enough resources available for scheduling.");
+        }
 
-            final Map<Integer, Set<ExecutionVertexID>> sharedSlotToVertexAssignment =
-                    determineParallelismAndAssignToFutureSlotIndex(
-                            containedJobVertices,
-                            slotsPerSlotSharingGroup,
-                            parallelismPerJobVertex);
+        Map<SlotSharingGroupId, Map<SlotInfo, ExecutionSlotSharingGroup>>
+                slotSharingSlotAssignments = slotSharingSlotAssignmentsOptional.get();
 
-            for (int i = 0; i < slotsPerSlotSharingGroup; i++) {
-                final SlotInfoWithUtilization slotInfo = slotIterator.next();
+        for (Map<SlotInfo, ExecutionSlotSharingGroup> slotSharingGroup :
+                slotSharingSlotAssignments.values()) {
 
-                final Set<ExecutionVertexID> containedExecutionVertices =
-                        sharedSlotToVertexAssignment.get(i);
+            for (Map.Entry<SlotInfo, ExecutionSlotSharingGroup> executionSlotSharingGroup :
+                    slotSharingGroup.entrySet()) {
+                final SharedSlot sharedSlot = reserveSharedSlot(executionSlotSharingGroup.getKey());
 
-                final SharedSlot sharedSlot = reserveSharedSlot(slotInfo);
-
-                for (ExecutionVertexID executionVertexId : containedExecutionVertices) {
+                for (ExecutionVertexID executionVertexId :
+                        executionSlotSharingGroup.getValue().getContainedExecutionVertices()) {
                     final LogicalSlot logicalSlot = sharedSlot.allocateLogicalSlot();
                     assignedSlots.put(executionVertexId, logicalSlot);
                 }
             }
         }
 
+        final Map<JobVertexID, Integer> parallelismPerJobVertex =
+                findMaxParallelisms(slotSharingSlotAssignments);
+
         return new ParallelismAndResourceAssignments(assignedSlots, parallelismPerJobVertex);
     }
 
-    private Map<Integer, Set<ExecutionVertexID>> determineParallelismAndAssignToFutureSlotIndex(
-            Collection<JobVertex> containedJobVertices,
-            int availableSlots,
-            // TODO: get rid of this parameter
-            Map<JobVertexID, Integer> parallelismPerJobVertex) {
-        final Map<Integer, Set<ExecutionVertexID>> sharedSlotToVertexAssignment = new HashMap<>();
-        for (JobVertex jobVertex : containedJobVertices) {
-            final int parallelism = Math.min(jobVertex.getParallelism(), availableSlots);
-            jobVertex.setParallelism(parallelism);
+    // TODO: This is a bit jank; the calculator could maybe just return this information as well
+    private Map<JobVertexID, Integer> findMaxParallelisms(
+            Map<SlotSharingGroupId, Map<SlotInfo, ExecutionSlotSharingGroup>>
+                    slotSharingSlotAssignments) {
 
-            parallelismPerJobVertex.put(jobVertex.getID(), parallelism);
-            for (int i = 0; i < parallelism; i++) {
-                sharedSlotToVertexAssignment
-                        .computeIfAbsent(i, ignored -> new HashSet<>())
-                        .add(new ExecutionVertexID(jobVertex.getID(), i));
-            }
-        }
-        return sharedSlotToVertexAssignment;
+        return slotSharingSlotAssignments.values().stream()
+                .flatMap(x -> x.values().stream())
+                .flatMap(x -> x.getContainedExecutionVertices().stream())
+                .collect(
+                        Collectors.toMap(
+                                ExecutionVertexID::getJobVertexId,
+                                v -> v.getSubtaskIndex() + 1,
+                                Math::max));
     }
 
     private SharedSlot reserveSharedSlot(SlotInfo slotInfo) {
@@ -596,30 +590,8 @@ public class DeclarativeScheduler implements SchedulerNG {
     }
 
     private void declareResources() {
-        desiredResources = calculateDesiredResources();
+        desiredResources = requirementsCalculator.calculateRequiredSlots(jobGraph.getVertices());
         declarativeSlotPool.increaseResourceRequirementsBy(desiredResources);
-    }
-
-    private ResourceCounter calculateDesiredResources() {
-        int numTotalRequiredSlots = 0;
-        for (Integer requiredSlots : getMaxParallelismForSlotSharingGroups(jobGraph).values()) {
-            numTotalRequiredSlots += requiredSlots;
-        }
-        return ResourceCounter.withResource(ResourceProfile.UNKNOWN, numTotalRequiredSlots);
-    }
-
-    private static Map<SlotSharingGroupId, Integer> getMaxParallelismForSlotSharingGroups(
-            JobGraph jobGraph) {
-        final Map<SlotSharingGroupId, Integer> maxParallelismForSlotSharingGroups = new HashMap<>();
-        for (JobVertex vertex : jobGraph.getVertices()) {
-            maxParallelismForSlotSharingGroups.compute(
-                    vertex.getSlotSharingGroup().getSlotSharingGroupId(),
-                    (slotSharingGroupId, currentMaxParallelism) ->
-                            currentMaxParallelism == null
-                                    ? vertex.getParallelism()
-                                    : Math.max(currentMaxParallelism, vertex.getParallelism()));
-        }
-        return maxParallelismForSlotSharingGroups;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.scheduler.declarative;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
@@ -48,6 +49,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionStateUpdateListener;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
@@ -57,7 +59,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
-import org.apache.flink.runtime.jobmanager.scheduler.Locality;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTrackerDeploymentListenerAdapter;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
@@ -67,7 +69,6 @@ import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPool;
 import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.ResourceCounter;
-import org.apache.flink.runtime.jobmaster.slotpool.SingleLogicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
 import org.apache.flink.runtime.jobmaster.slotpool.ThrowingSlotProvider;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
@@ -81,8 +82,10 @@ import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.query.KvStateLocation;
 import org.apache.flink.runtime.query.UnknownKvStateLocation;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
+import org.apache.flink.runtime.scheduler.ExecutionSlotSharingGroup;
 import org.apache.flink.runtime.scheduler.SchedulerNG;
 import org.apache.flink.runtime.scheduler.SchedulerUtils;
+import org.apache.flink.runtime.scheduler.SharedSlot;
 import org.apache.flink.runtime.scheduler.UpdateSchedulerNgOnInternalFailuresListener;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
@@ -103,12 +106,16 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
  * Declarative {@link SchedulerNG} implementation which first declares the required resources and
@@ -471,42 +478,89 @@ public class DeclarativeScheduler implements SchedulerNG {
 
         final Collection<SlotInfoWithUtilization> freeSlots =
                 declarativeSlotPool.getFreeSlotsInformation();
-        final int slotsPerVertex = freeSlots.size() / jobGraph.getNumberOfVertices();
+        // TODO: This can waste slots if the max parallelism for slot sharing groups is not equal
+        final int slotsPerSlotSharingGroup =
+                freeSlots.size() / jobGraph.getSlotSharingGroups().size();
         final Iterator<SlotInfoWithUtilization> slotIterator = freeSlots.iterator();
 
-        for (JobVertex jobVertex : jobGraph.getVerticesSortedTopologicallyFromSources()) {
-            final int parallelism = Math.min(jobVertex.getParallelism(), slotsPerVertex);
-            jobVertex.setParallelism(parallelism);
+        for (SlotSharingGroup slotSharingGroup : jobGraph.getSlotSharingGroups()) {
+            final List<JobVertex> containedJobVertices =
+                    slotSharingGroup.getJobVertexIds().stream()
+                            .map(jobGraph::findVertexByID)
+                            .collect(Collectors.toList());
 
-            parallelismPerJobVertex.put(jobVertex.getID(), parallelism);
+            final Map<Integer, Set<ExecutionVertexID>> sharedSlotToVertexAssignment =
+                    determineParallelismAndAssignToFutureSlotIndex(
+                            containedJobVertices,
+                            slotsPerSlotSharingGroup,
+                            parallelismPerJobVertex);
 
-            for (int i = 0; i < slotsPerVertex; i++) {
+            for (int i = 0; i < slotsPerSlotSharingGroup; i++) {
                 final SlotInfoWithUtilization slotInfo = slotIterator.next();
 
-                final PhysicalSlot physicalSlot =
-                        declarativeSlotPool.reserveFreeSlot(
-                                slotInfo.getAllocationId(),
-                                ResourceProfile.fromResourceSpec(
-                                        jobVertex.getMinResources(), MemorySize.ZERO));
+                final Set<ExecutionVertexID> containedExecutionVertices =
+                        sharedSlotToVertexAssignment.get(i);
 
-                final SingleLogicalSlot logicalSlot =
-                        new SingleLogicalSlot(
-                                new SlotRequestId(),
-                                physicalSlot,
-                                null,
-                                Locality.UNKNOWN,
-                                slot ->
-                                        declarativeSlotPool.freeReservedSlot(
-                                                physicalSlot.getAllocationId(),
-                                                null,
-                                                System.currentTimeMillis()));
-                physicalSlot.tryAssignPayload(logicalSlot);
+                final SharedSlot sharedSlot =
+                        reserveSharedSlot(slotInfo, containedExecutionVertices);
 
-                assignedSlots.put(new ExecutionVertexID(jobVertex.getID(), i), logicalSlot);
+                for (ExecutionVertexID executionVertexId : containedExecutionVertices) {
+                    final LogicalSlot logicalSlot;
+                    try {
+                        logicalSlot = sharedSlot.allocateLogicalSlot(executionVertexId).get();
+                    } catch (InterruptedException | ExecutionException e) {
+                        throw new RuntimeException("Should not have failed.");
+                    }
+                    assignedSlots.put(executionVertexId, logicalSlot);
+                }
             }
         }
 
         return new ParallelismAndResourceAssignments(assignedSlots, parallelismPerJobVertex);
+    }
+
+    private Map<Integer, Set<ExecutionVertexID>> determineParallelismAndAssignToFutureSlotIndex(
+            Collection<JobVertex> containedJobVertices,
+            int availableSlots,
+            // TODO: get rid of this parameter
+            Map<JobVertexID, Integer> parallelismPerJobVertex) {
+        final Map<Integer, Set<ExecutionVertexID>> sharedSlotToVertexAssignment = new HashMap<>();
+        for (JobVertex jobVertex : containedJobVertices) {
+            final int parallelism = Math.min(jobVertex.getParallelism(), availableSlots);
+            jobVertex.setParallelism(parallelism);
+
+            parallelismPerJobVertex.put(jobVertex.getID(), parallelism);
+            for (int i = 0; i < parallelism; i++) {
+                sharedSlotToVertexAssignment
+                        .computeIfAbsent(i, ignored -> new HashSet<>())
+                        .add(new ExecutionVertexID(jobVertex.getID(), i));
+            }
+        }
+        return sharedSlotToVertexAssignment;
+    }
+
+    private SharedSlot reserveSharedSlot(
+            SlotInfo slotInfo, Set<ExecutionVertexID> containedExecutionVertices) {
+        final PhysicalSlot physicalSlot =
+                declarativeSlotPool.reserveFreeSlot(
+                        slotInfo.getAllocationId(),
+                        ResourceProfile.fromResourceSpec(ResourceSpec.DEFAULT, MemorySize.ZERO));
+
+        final SharedSlot sharedSlot =
+                new SharedSlot(
+                        new SlotRequestId(),
+                        slotInfo.getResourceProfile(),
+                        ExecutionSlotSharingGroup.forVertexIds(containedExecutionVertices),
+                        CompletableFuture.completedFuture(physicalSlot),
+                        slotInfo.willBeOccupiedIndefinitely(),
+                        ignored ->
+                                declarativeSlotPool.freeReservedSlot(
+                                        slotInfo.getAllocationId(),
+                                        null,
+                                        System.currentTimeMillis()));
+        physicalSlot.tryAssignPayload(sharedSlot);
+
+        return sharedSlot;
     }
 
     static final class ParallelismAndResourceAssignments {
@@ -559,13 +613,25 @@ public class DeclarativeScheduler implements SchedulerNG {
     }
 
     private ResourceCounter calculateDesiredResources() {
-        int counter = 0;
-
-        for (JobVertex vertex : jobGraph.getVertices()) {
-            counter += vertex.getParallelism();
+        int numTotalRequiredSlots = 0;
+        for (Integer requiredSlots : getMaxParallelismForSlotSharingGroups(jobGraph).values()) {
+            numTotalRequiredSlots += requiredSlots;
         }
+        return ResourceCounter.withResource(ResourceProfile.UNKNOWN, numTotalRequiredSlots);
+    }
 
-        return ResourceCounter.withResource(ResourceProfile.UNKNOWN, counter);
+    private static Map<SlotSharingGroupId, Integer> getMaxParallelismForSlotSharingGroups(
+            JobGraph jobGraph) {
+        final Map<SlotSharingGroupId, Integer> maxParallelismForSlotSharingGroups = new HashMap<>();
+        for (JobVertex vertex : jobGraph.getVertices()) {
+            maxParallelismForSlotSharingGroups.compute(
+                    vertex.getSlotSharingGroup().getSlotSharingGroupId(),
+                    (slotSharingGroupId, currentMaxParallelism) ->
+                            currentMaxParallelism == null
+                                    ? vertex.getParallelism()
+                                    : Math.max(currentMaxParallelism, vertex.getParallelism()));
+        }
+        return maxParallelismForSlotSharingGroups;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerNG.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.scheduler.declarative;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
@@ -60,7 +61,6 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
-import org.apache.flink.runtime.jobmanager.scheduler.Locality;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTrackerDeploymentListenerAdapter;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
@@ -70,8 +70,6 @@ import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPool;
 import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.ResourceCounter;
-import org.apache.flink.runtime.jobmaster.slotpool.SingleLogicalSlot;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
 import org.apache.flink.runtime.jobmaster.slotpool.ThrowingSlotProvider;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
@@ -110,6 +108,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -149,6 +148,10 @@ public class DeclarativeSchedulerNG implements SchedulerNG {
             new ComponentMainThreadExecutor.DummyComponentMainThreadExecutor("foobar");
 
     @Nullable private JobStatusListener jobStatusListener;
+
+    private final RequirementsCalculator requirementsCalculator =
+            new SlotSharingRequirementsCalculator();
+    private final MappingCalculator mappingCalculator = new SlotSharingMappingCalculator();
 
     private State state = new Created();
 
@@ -237,13 +240,7 @@ public class DeclarativeSchedulerNG implements SchedulerNG {
     }
 
     private ResourceCounter calculateDesiredResources() {
-        int counter = 0;
-
-        for (JobVertex vertex : jobGraph.getVertices()) {
-            counter += vertex.getParallelism();
-        }
-
-        return ResourceCounter.withResource(ResourceProfile.UNKNOWN, counter);
+        return requirementsCalculator.calculateRequiredSlots(jobGraph.getVertices());
     }
 
     private ExecutionGraph createExecutionGraphAndRestoreState() throws Exception {
@@ -670,49 +667,64 @@ public class DeclarativeSchedulerNG implements SchedulerNG {
         }
 
         private DeclarativeScheduler.ParallelismAndResourceAssignments
-                determineParallelismAndAssignResources(JobGraph jobGraph) {
+                determineParallelismAndAssignResources(JobGraph jobGraph)
+                        throws JobExecutionException {
             final HashMap<ExecutionVertexID, LogicalSlot> assignedSlots = new HashMap<>();
-            final HashMap<JobVertexID, Integer> parallelismPerJobVertex = new HashMap<>();
 
-            final Collection<SlotInfoWithUtilization> freeSlots =
-                    declarativeSlotPool.getFreeSlotsInformation();
-            final int slotsPerVertex = freeSlots.size() / jobGraph.getNumberOfVertices();
-            final Iterator<SlotInfoWithUtilization> slotIterator = freeSlots.iterator();
+            final Optional<SlotSharingAssignments> slotSharingSlotAssignmentsOptional =
+                    mappingCalculator.determineParallelismAndAssignResources(
+                            new JobGraphJobInformation(jobGraph),
+                            declarativeSlotPool.getFreeSlotsInformation());
 
-            for (JobVertex jobVertex : jobGraph.getVerticesSortedTopologicallyFromSources()) {
-                final int parallelism = Math.min(jobVertex.getParallelism(), slotsPerVertex);
-                jobVertex.setParallelism(parallelism);
+            if (!slotSharingSlotAssignmentsOptional.isPresent()) {
+                throw new JobExecutionException(
+                        jobGraph.getJobID(), "Not enough resources available for scheduling.");
+            }
 
-                parallelismPerJobVertex.put(jobVertex.getID(), parallelism);
+            final SlotSharingAssignments slotSharingSlotAssignments =
+                    slotSharingSlotAssignmentsOptional.get();
 
-                for (int i = 0; i < slotsPerVertex; i++) {
-                    final SlotInfoWithUtilization slotInfo = slotIterator.next();
+            for (ExecutionSlotSharingGroupAndSlot executionSlotSharingGroup :
+                    slotSharingSlotAssignments.getAssignments()) {
+                final SharedSlot sharedSlot =
+                        reserveSharedSlot(executionSlotSharingGroup.getSlotInfo());
 
-                    final PhysicalSlot physicalSlot =
-                            declarativeSlotPool.reserveFreeSlot(
-                                    slotInfo.getAllocationId(),
-                                    ResourceProfile.fromResourceSpec(
-                                            jobVertex.getMinResources(), MemorySize.ZERO));
-
-                    final SingleLogicalSlot logicalSlot =
-                            new SingleLogicalSlot(
-                                    new SlotRequestId(),
-                                    physicalSlot,
-                                    null,
-                                    Locality.UNKNOWN,
-                                    slot ->
-                                            declarativeSlotPool.freeReservedSlot(
-                                                    physicalSlot.getAllocationId(),
-                                                    null,
-                                                    System.currentTimeMillis()));
-                    physicalSlot.tryAssignPayload(logicalSlot);
-
-                    assignedSlots.put(new ExecutionVertexID(jobVertex.getID(), i), logicalSlot);
+                for (ExecutionVertexID executionVertexId :
+                        executionSlotSharingGroup
+                                .getExecutionSlotSharingGroup()
+                                .getContainedExecutionVertices()) {
+                    final LogicalSlot logicalSlot = sharedSlot.allocateLogicalSlot();
+                    assignedSlots.put(executionVertexId, logicalSlot);
                 }
             }
 
+            final Map<JobVertexID, Integer> parallelismPerJobVertex =
+                    slotSharingSlotAssignments.getMaxParallelismForVertices();
+
             return new DeclarativeScheduler.ParallelismAndResourceAssignments(
                     assignedSlots, parallelismPerJobVertex);
+        }
+
+        private SharedSlot reserveSharedSlot(SlotInfo slotInfo) {
+            final PhysicalSlot physicalSlot =
+                    declarativeSlotPool.reserveFreeSlot(
+                            slotInfo.getAllocationId(),
+                            ResourceProfile.fromResourceSpec(
+                                    ResourceSpec.DEFAULT, MemorySize.ZERO));
+
+            final SharedSlot sharedSlot =
+                    new SharedSlot(
+                            new SlotRequestId(),
+                            physicalSlot,
+                            slotInfo.willBeOccupiedIndefinitely(),
+                            () ->
+                                    declarativeSlotPool.freeReservedSlot(
+                                            slotInfo.getAllocationId(),
+                                            null,
+                                            System.currentTimeMillis()));
+            physicalSlot.tryAssignPayload(sharedSlot);
+
+            return sharedSlot;
         }
 
         @Nonnull

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/ExecutionSlotSharingGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/ExecutionSlotSharingGroup.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * A parallel instance of a slot sharing group, containing exactly 1 subtask of some or all vertices
+ * belonging the same slot sharing group.
+ */
+class ExecutionSlotSharingGroup {
+    private final Set<ExecutionVertexID> containedExecutionVertices;
+
+    public ExecutionSlotSharingGroup(Set<ExecutionVertexID> containedExecutionVertices) {
+        this.containedExecutionVertices = containedExecutionVertices;
+    }
+
+    public Collection<ExecutionVertexID> getContainedExecutionVertices() {
+        return containedExecutionVertices;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/ExecutionSlotSharingGroupAndSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/ExecutionSlotSharingGroupAndSlot.java
@@ -17,22 +17,24 @@
 
 package org.apache.flink.runtime.scheduler.declarative;
 
-import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
 
-import java.util.Collection;
-import java.util.Optional;
+/** An execution slot sharing group and the slot it could be assigned to. */
+public class ExecutionSlotSharingGroupAndSlot {
+    private final ExecutionSlotSharingGroup executionSlotSharingGroup;
+    private final SlotInfo slotInfo;
 
-/** Calculates a potential mapping between slots & * vertices. */
-public interface MappingCalculator {
+    public ExecutionSlotSharingGroupAndSlot(
+            ExecutionSlotSharingGroup executionSlotSharingGroup, SlotInfo slotInfo) {
+        this.executionSlotSharingGroup = executionSlotSharingGroup;
+        this.slotInfo = slotInfo;
+    }
 
-    /**
-     * Attempts to create a mapping between vertices and slots.
-     *
-     * @param jobInformation information about the job graph
-     * @param freeSlots currently free slots
-     * @return mapping of slots and the vertices that should be deployed into them, if a mapping
-     *     could be found
-     */
-    Optional<SlotSharingAssignments> determineParallelismAndAssignResources(
-            JobInformation jobInformation, Collection<SlotInfoWithUtilization> freeSlots);
+    public ExecutionSlotSharingGroup getExecutionSlotSharingGroup() {
+        return executionSlotSharingGroup;
+    }
+
+    public SlotInfo getSlotInfo() {
+        return slotInfo;
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/JobGraphJobInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/JobGraphJobInformation.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+
+import java.util.Collection;
+
+/** TODO: Add javadoc. */
+public class JobGraphJobInformation implements JobInformation {
+
+    private final JobGraph jobGraph;
+
+    public JobGraphJobInformation(JobGraph jobGraph) {
+        this.jobGraph = jobGraph;
+    }
+
+    @Override
+    public Collection<SlotSharingGroup> getSlotSharingGroups() {
+        return jobGraph.getSlotSharingGroups();
+    }
+
+    @Override
+    public VertexInformation getVertexInformation(JobVertexID jobVertexId) {
+        return new JobVertexInformation(jobGraph.findVertexByID(jobVertexId));
+    }
+
+    private static class JobVertexInformation implements VertexInformation {
+
+        private final JobVertex jobVertex;
+
+        private JobVertexInformation(JobVertex jobVertex) {
+            this.jobVertex = jobVertex;
+        }
+
+        @Override
+        public JobVertexID getJobVertexID() {
+            return jobVertex.getID();
+        }
+
+        @Override
+        public int getParallelism() {
+            return jobVertex.getParallelism();
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/JobInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/JobInformation.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+
+import java.util.Collection;
+
+/** Information about the job. */
+public interface JobInformation {
+    Collection<SlotSharingGroup> getSlotSharingGroups();
+
+    VertexInformation getVertexInformation(JobVertexID jobVertexId);
+
+    /** Information about a single vertex. */
+    interface VertexInformation {
+        JobVertexID getJobVertexID();
+
+        int getParallelism();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/MappingCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/MappingCalculator.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+
+/** Calculates a potential mapping between slots & * vertices. */
+public interface MappingCalculator {
+
+    /**
+     * Attempts to create a mapping between vertices and slots.
+     *
+     * @param jobInformation information about the job graph
+     * @param freeSlots currently free slots
+     * @return mapping of slots and the vertices that should be deployed into them, if a mapping
+     *     could be found
+     */
+    // TODO: add a new data structure for the return value that is easier to understand
+    Optional<Map<SlotSharingGroupId, Map<SlotInfo, ExecutionSlotSharingGroup>>>
+            determineParallelismAndAssignResources(
+                    JobInformation jobInformation, Collection<SlotInfoWithUtilization> freeSlots);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/RequirementsCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/RequirementsCalculator.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmaster.slotpool.ResourceCounter;
+
+/** Calculates resource requirements for a set of vertices. */
+public interface RequirementsCalculator {
+
+    /**
+     * Calculates the total resources required for scheduling the given vertices.
+     *
+     * @param vertices vertices to schedule
+     * @return required resources
+     */
+    // TODO: replace JobVertex with VertexInformation
+    ResourceCounter calculateRequiredSlots(Iterable<JobVertex> vertices);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/SharedSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/SharedSlot.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.jobmanager.scheduler.Locality;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotOwner;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlot;
+import org.apache.flink.runtime.jobmaster.slotpool.SingleLogicalSlot;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Shared slot implementation for the {@link DeclarativeScheduler}. */
+public class SharedSlot implements SlotOwner, PhysicalSlot.Payload {
+    private static final Logger LOG = LoggerFactory.getLogger(SharedSlot.class);
+
+    private final SlotRequestId physicalSlotRequestId;
+
+    private final PhysicalSlot physicalSlot;
+
+    private final Runnable externalReleaseCallback;
+
+    private final Map<SlotRequestId, LogicalSlot> allocatedLogicalSlots;
+
+    private final boolean slotWillBeOccupiedIndefinitely;
+
+    private State state;
+
+    public SharedSlot(
+            SlotRequestId physicalSlotRequestId,
+            PhysicalSlot physicalSlot,
+            boolean slotWillBeOccupiedIndefinitely,
+            Runnable externalReleaseCallback) {
+        this.physicalSlotRequestId = physicalSlotRequestId;
+        this.physicalSlot = physicalSlot;
+        this.slotWillBeOccupiedIndefinitely = slotWillBeOccupiedIndefinitely;
+        this.externalReleaseCallback = externalReleaseCallback;
+        this.state = State.ALLOCATED;
+        this.allocatedLogicalSlots = new HashMap<>();
+        physicalSlot.tryAssignPayload(this);
+    }
+
+    /**
+     * Registers an allocation request for a logical slot.
+     *
+     * <p>The logical slot request is complete once the underlying physical slot request is
+     * complete.
+     *
+     * @return the logical slot
+     */
+    public LogicalSlot allocateLogicalSlot() {
+        LOG.debug("Allocating logical slot from shared slot ({})", physicalSlotRequestId);
+        return new SingleLogicalSlot(
+                new SlotRequestId(),
+                physicalSlot,
+                null,
+                Locality.UNKNOWN,
+                this,
+                slotWillBeOccupiedIndefinitely);
+    }
+
+    @Override
+    public void returnLogicalSlot(LogicalSlot logicalSlot) {
+        LOG.debug("Returning logical slot to shared slot ({})", physicalSlotRequestId);
+        Preconditions.checkState(
+                allocatedLogicalSlots.remove(logicalSlot.getSlotRequestId()) != null,
+                "Trying to remove a logical slot request which has been either already removed or never created.");
+        tryReleaseExternally();
+    }
+
+    @Override
+    public void release(Throwable cause) {
+        LOG.debug("Release shared slot ({})", physicalSlotRequestId);
+
+        // copy the logical slot collection to avoid ConcurrentModificationException
+        // if logical slot releases cause cancellation of other executions
+        // which will try to call returnLogicalSlot and modify requestedLogicalSlots collection
+        final List<LogicalSlot> collect = new ArrayList<>(allocatedLogicalSlots.values());
+        for (LogicalSlot allocatedLogicalSlot : collect) {
+            allocatedLogicalSlot.releaseSlot(cause);
+        }
+        allocatedLogicalSlots.clear();
+        tryReleaseExternally();
+    }
+
+    private void tryReleaseExternally() {
+        if (state != State.RELEASED && allocatedLogicalSlots.isEmpty()) {
+            state = State.RELEASED;
+            LOG.debug("Release shared slot externally ({})", physicalSlotRequestId);
+            externalReleaseCallback.run();
+        }
+    }
+
+    @Override
+    public boolean willOccupySlotIndefinitely() {
+        return slotWillBeOccupiedIndefinitely;
+    }
+
+    private enum State {
+        ALLOCATED,
+        RELEASED
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/SlotSharingAssignments.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/SlotSharingAssignments.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** Mapping of slots to execution slot sharing groups. */
+public class SlotSharingAssignments {
+
+    private final Collection<ExecutionSlotSharingGroupAndSlot> assignments;
+
+    public SlotSharingAssignments(Collection<ExecutionSlotSharingGroupAndSlot> assignments) {
+        this.assignments = assignments;
+    }
+
+    public Iterable<ExecutionSlotSharingGroupAndSlot> getAssignments() {
+        return assignments;
+    }
+
+    public Map<JobVertexID, Integer> getMaxParallelismForVertices() {
+        return assignments.stream()
+                .map(ExecutionSlotSharingGroupAndSlot::getExecutionSlotSharingGroup)
+                .flatMap(x -> x.getContainedExecutionVertices().stream())
+                .collect(
+                        Collectors.toMap(
+                                ExecutionVertexID::getJobVertexId,
+                                v -> v.getSubtaskIndex() + 1,
+                                Math::max));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/SlotSharingMappingCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/SlotSharingMappingCalculator.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** {@link MappingCalculator} that supports slot sharing. */
+public class SlotSharingMappingCalculator implements MappingCalculator {
+
+    @Override
+    public Optional<Map<SlotSharingGroupId, Map<SlotInfo, ExecutionSlotSharingGroup>>>
+            determineParallelismAndAssignResources(
+                    JobInformation jobInformation, Collection<SlotInfoWithUtilization> freeSlots) {
+
+        // TODO: This can waste slots if the max parallelism for slot sharing groups is not equal
+        final int slotsPerSlotSharingGroup =
+                freeSlots.size() / jobInformation.getSlotSharingGroups().size();
+        final Iterator<SlotInfoWithUtilization> slotIterator = freeSlots.iterator();
+
+        Map<SlotSharingGroupId, Map<SlotInfo, ExecutionSlotSharingGroup>>
+                slotSharingSlotAssignments = new HashMap<>();
+
+        for (SlotSharingGroup slotSharingGroup : jobInformation.getSlotSharingGroups()) {
+            final List<JobInformation.VertexInformation> containedJobVertices =
+                    slotSharingGroup.getJobVertexIds().stream()
+                            .map(jobInformation::getVertexInformation)
+                            .collect(Collectors.toList());
+
+            final Iterable<ExecutionSlotSharingGroup> sharedSlotToVertexAssignment =
+                    determineParallelismAndAssignToFutureSlotIndex(
+                            containedJobVertices, slotsPerSlotSharingGroup);
+
+            Map<SlotInfo, ExecutionSlotSharingGroup> slotAssignments = new HashMap<>();
+            for (ExecutionSlotSharingGroup executionSlotSharingGroup :
+                    sharedSlotToVertexAssignment) {
+                final SlotInfoWithUtilization slotInfo = slotIterator.next();
+
+                slotAssignments.put(slotInfo, executionSlotSharingGroup);
+            }
+            slotSharingSlotAssignments.put(
+                    slotSharingGroup.getSlotSharingGroupId(), slotAssignments);
+        }
+
+        return Optional.of(slotSharingSlotAssignments);
+    }
+
+    private Iterable<ExecutionSlotSharingGroup> determineParallelismAndAssignToFutureSlotIndex(
+            Collection<JobInformation.VertexInformation> containedJobVertices, int availableSlots) {
+        final Map<Integer, Set<ExecutionVertexID>> sharedSlotToVertexAssignment = new HashMap<>();
+        for (JobInformation.VertexInformation jobVertex : containedJobVertices) {
+            final int parallelism = Math.min(jobVertex.getParallelism(), availableSlots);
+
+            for (int i = 0; i < parallelism; i++) {
+                sharedSlotToVertexAssignment
+                        .computeIfAbsent(i, ignored -> new HashSet<>())
+                        .add(new ExecutionVertexID(jobVertex.getJobVertexID(), i));
+            }
+        }
+
+        return sharedSlotToVertexAssignment.values().stream()
+                .map(ExecutionSlotSharingGroup::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/SlotSharingRequirementsCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/SlotSharingRequirementsCalculator.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmaster.slotpool.ResourceCounter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** {@link RequirementsCalculator} that supports slot sharing. */
+public class SlotSharingRequirementsCalculator implements RequirementsCalculator {
+
+    @Override
+    public ResourceCounter calculateRequiredSlots(Iterable<JobVertex> vertices) {
+        int numTotalRequiredSlots = 0;
+        for (Integer requiredSlots : getMaxParallelismForSlotSharingGroups(vertices).values()) {
+            numTotalRequiredSlots += requiredSlots;
+        }
+        return ResourceCounter.withResource(ResourceProfile.UNKNOWN, numTotalRequiredSlots);
+    }
+
+    private static Map<SlotSharingGroupId, Integer> getMaxParallelismForSlotSharingGroups(
+            Iterable<JobVertex> vertices) {
+        final Map<SlotSharingGroupId, Integer> maxParallelismForSlotSharingGroups = new HashMap<>();
+        for (JobVertex vertex : vertices) {
+            maxParallelismForSlotSharingGroups.compute(
+                    vertex.getSlotSharingGroup().getSlotSharingGroupId(),
+                    (slotSharingGroupId, currentMaxParallelism) ->
+                            currentMaxParallelism == null
+                                    ? vertex.getParallelism()
+                                    : Math.max(currentMaxParallelism, vertex.getParallelism()));
+        }
+        return maxParallelismForSlotSharingGroups;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSlotSharingITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSlotSharingITCase.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.dispatcher.SchedulerNGFactoryFactory;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.runtime.testutils.MiniClusterResource;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/** SlotSharing tests for the {@link DeclarativeScheduler}. */
+public class DeclarativeSchedulerSlotSharingITCase extends TestLogger {
+
+    private static final int NUMBER_TASK_MANAGERS = 1;
+    private static final int NUMBER_SLOTS_PER_TASK_MANAGER = 1;
+    private static final int PARALLELISM = 10;
+
+    private static Configuration getConfiguration() {
+        final Configuration configuration = new Configuration();
+
+        configuration.set(
+                JobManagerOptions.SCHEDULER, SchedulerNGFactoryFactory.DECLARATIVE_SCHEDULER);
+        configuration.set(ClusterOptions.ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT, true);
+
+        return configuration;
+    }
+
+    @ClassRule
+    public static final MiniClusterResource MINI_CLUSTER_RESOURCE =
+            new MiniClusterResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setConfiguration(getConfiguration())
+                            .setNumberTaskManagers(NUMBER_TASK_MANAGERS)
+                            .setNumberSlotsPerTaskManager(NUMBER_SLOTS_PER_TASK_MANAGER)
+                            .build());
+
+    @Test
+    public void testSchedulingOfJobRequiringSlotSharing() throws Exception {
+        // run job multiple times to ensure slots are cleaned up properly
+        runJob();
+        runJob();
+    }
+
+    private void runJob() throws Exception {
+        final MiniCluster miniCluster = MINI_CLUSTER_RESOURCE.getMiniCluster();
+        final JobGraph jobGraph = createJobGraph();
+
+        miniCluster.submitJob(jobGraph).join();
+
+        final JobResult jobResult = miniCluster.requestJobResult(jobGraph.getJobID()).join();
+
+        // this throws an exception if the job failed
+        jobResult.toJobExecutionResult(getClass().getClassLoader());
+
+        assertTrue(jobResult.isSuccess());
+    }
+
+    /**
+     * Returns a JobGraph that requires slot sharing to work in order to be able to run with a
+     * single slot.
+     */
+    private static JobGraph createJobGraph() {
+        final SlotSharingGroup slotSharingGroup = new SlotSharingGroup();
+
+        final JobVertex source = new JobVertex("Source");
+        source.setInvokableClass(NoOpInvokable.class);
+        source.setParallelism(PARALLELISM);
+        source.setSlotSharingGroup(slotSharingGroup);
+
+        final JobVertex sink = new JobVertex("sink");
+        sink.setInvokableClass(NoOpInvokable.class);
+        sink.setParallelism(PARALLELISM);
+        sink.setSlotSharingGroup(slotSharingGroup);
+
+        sink.connectNewDataSetAsInput(
+                source, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
+
+        return new JobGraph("Simple job", source, sink);
+    }
+}


### PR DESCRIPTION
Based on #9.

First prototype for moving the calculation of resources/mappings into separate component(s).

For this prototype I've defined 2 new interfaces (`RequirementCalculator`, `MappingCalculator`) so far.

The requirement calculator is only responsible for calculating how many slots would be required given a set of vertices & slot sharing groups.
The mapping calculator returns an optional mapping between a collection of free slots and vertices to schedule.

I went with separate components contrary to our earlier conclusion because I have the impression that having these in 1 component would lead to wrong assumptions being made during the implementation.
FWIW, the resources being provided to the mapping calculator may not resemble in any was what was returned by the requirement calculator, yet it must be able to process it in some form.
Furthermore, it is easily conceivable that a given requirement can be fulfilled by various mappings; imagine a requirement calculator that just requests infinite slots, or 1 slot per vertex.

The mapping calculator does not do any slot reservations, so that it doesn't require a dependency on the slot pool. I think this will simplify testing, and could allow the scheduler to test whether a job can be schedules without immediately triggering said scheduling, for example to answer questions like "_Could_ I run this job if I scaled up this vertex?".
Because of this however the concept of slot sharing groups cannot be an internal detail of the calculators, and must be exposed such that the scheduler (or some allocating component) can handle it appropriately. This currently implies that we would _always_ create shared slots, even if there is only a single vertex to schedule, but that seems kinda alright.

The mapping calculator does not work directly on the JobGraph but a new abstraction exposing some details about it (slot sharing groups, vertex lookup), which naturally can be extended in the future for things like prior locations and such.