### PR TITLE
improve declarative resource management switch

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -112,9 +112,11 @@ public class ClusterOptions {
                             "Defines whether the cluster uses declarative resource management.");
 
     public static boolean isDeclarativeResourceManagementEnabled(Configuration configuration) {
-        return configuration.get(ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT)
-                        && !System.getProperties().containsKey("flink.tests.disable-declarative")
-                || isDeclarativeSchedulerEnabled(configuration);
+        if (configuration.contains(ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT)) {
+            return configuration.get(ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT);
+        } else {
+            return !System.getProperties().containsKey("flink.tests.disable-declarative");
+        }
     }
 
     public static JobManagerOptions.SchedulerType getSchedulerType(Configuration configuration) {


### PR DESCRIPTION
The current switch has a problem where the `flink.tests.disable-declarative` property took precedence over everything else, causing tests that explicitly opt-in to declarative resource management to still be run without it.