### PR TITLE
Setup CI profile

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -113,7 +113,8 @@ public class ClusterOptions {
 
     public static boolean isDeclarativeResourceManagementEnabled(Configuration configuration) {
         return configuration.get(ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT)
-                && !System.getProperties().containsKey("flink.tests.disable-declarative");
+                        && !System.getProperties().containsKey("flink.tests.disable-declarative")
+                || isDeclarativeSchedulerEnabled(configuration);
     }
 
     public static boolean isDeclarativeSchedulerEnabled(Configuration configuration) {

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -115,4 +115,9 @@ public class ClusterOptions {
         return configuration.get(ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT)
                 && !System.getProperties().containsKey("flink.tests.disable-declarative");
     }
+
+    public static boolean isDeclarativeSchedulerEnabled(Configuration configuration) {
+        return configuration.get(JobManagerOptions.SCHEDULER)
+                == JobManagerOptions.SchedulerType.Declarative;
+    }
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -117,8 +117,20 @@ public class ClusterOptions {
                 || isDeclarativeSchedulerEnabled(configuration);
     }
 
+    public static JobManagerOptions.SchedulerType getSchedulerType(Configuration configuration) {
+        if (isDeclarativeSchedulerEnabled(configuration)) {
+            return JobManagerOptions.SchedulerType.Declarative;
+        } else {
+            return configuration.get(JobManagerOptions.SCHEDULER);
+        }
+    }
+
     public static boolean isDeclarativeSchedulerEnabled(Configuration configuration) {
-        return configuration.get(JobManagerOptions.SCHEDULER)
-                == JobManagerOptions.SchedulerType.Declarative;
+        if (configuration.contains(JobManagerOptions.SCHEDULER)) {
+            return configuration.get(JobManagerOptions.SCHEDULER)
+                    == JobManagerOptions.SchedulerType.Declarative;
+        } else {
+            return System.getProperties().containsKey("flink.tests.enable-declarative-scheduler");
+        }
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -358,6 +358,19 @@ public class JobManagerOptions {
                                     .list(text("'ng': new generation scheduler"))
                                     .build());
 
+    /** Config parameter determining the declarative scheduler implementation. */
+    @Documentation.ExcludeFromDocumentation("Declarative scheduler is still in development.")
+    public static final ConfigOption<DeclarativeSchedulerType> DECLARATIVE_SCHEDULER_TYPE =
+            key("jobmanager.scheduler.declarative-scheduler-type")
+                    .enumType(DeclarativeSchedulerType.class)
+                    .defaultValue(DeclarativeSchedulerType.StateMachine);
+
+    /** Type of declarative scheduler implementation. */
+    public enum DeclarativeSchedulerType {
+        Old,
+        StateMachine,
+    }
+
     /**
      * Config parameter controlling whether partitions should already be released during the job
      * execution.

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -347,16 +347,22 @@ public class JobManagerOptions {
 
     /** Config parameter determining the scheduler implementation. */
     @Documentation.ExcludeFromDocumentation("SchedulerNG is still in development.")
-    public static final ConfigOption<String> SCHEDULER =
+    public static final ConfigOption<SchedulerType> SCHEDULER =
             key("jobmanager.scheduler")
-                    .stringType()
-                    .defaultValue("ng")
+                    .enumType(SchedulerType.class)
+                    .defaultValue(SchedulerType.Ng)
                     .withDescription(
                             Description.builder()
                                     .text(
                                             "Determines which scheduler implementation is used to schedule tasks. Accepted values are:")
                                     .list(text("'ng': new generation scheduler"))
                                     .build());
+
+    /** Type of scheduler implementation. */
+    public enum SchedulerType {
+        Ng,
+        Declarative
+    }
 
     /** Config parameter determining the declarative scheduler implementation. */
     @Documentation.ExcludeFromDocumentation("Declarative scheduler is still in development.")

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerFactory.java
@@ -29,7 +29,7 @@ import org.apache.flink.runtime.jobmaster.JobMasterConfiguration;
 import org.apache.flink.runtime.jobmaster.factories.DefaultJobMasterServiceFactory;
 import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.jobmaster.factories.JobMasterServiceFactory;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolServiceFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
@@ -56,7 +56,8 @@ public enum DefaultJobManagerRunnerFactory implements JobManagerRunnerFactory {
         final JobMasterConfiguration jobMasterConfiguration =
                 JobMasterConfiguration.fromConfiguration(configuration);
 
-        final SlotPoolFactory slotPoolFactory = SlotPoolFactory.fromConfiguration(configuration);
+        final SlotPoolServiceFactory slotPoolFactory =
+                SlotPoolServiceFactory.fromConfiguration(configuration);
         final SchedulerNGFactory schedulerNGFactory =
                 SchedulerNGFactoryFactory.createSchedulerNGFactory(configuration);
         final ShuffleMaster<?> shuffleMaster =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SchedulerNGFactoryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SchedulerNGFactoryFactory.java
@@ -19,6 +19,7 @@
 
 package org.apache.flink.runtime.dispatcher;
 
+import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.scheduler.DefaultSchedulerFactory;
@@ -32,7 +33,7 @@ public final class SchedulerNGFactoryFactory {
 
     public static SchedulerNGFactory createSchedulerNGFactory(final Configuration configuration) {
         final JobManagerOptions.SchedulerType schedulerTyp =
-                configuration.get(JobManagerOptions.SCHEDULER);
+                ClusterOptions.getSchedulerType(configuration);
         switch (schedulerTyp) {
             case Ng:
                 return new DefaultSchedulerFactory();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SchedulerNGFactoryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SchedulerNGFactoryFactory.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
 public final class SchedulerNGFactoryFactory {
 
     public static final String SCHEDULER_TYPE_NG = "ng";
+    public static final String DECLARATIVE_SCHEDULER = "declarative";
 
     private SchedulerNGFactoryFactory() {}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SchedulerNGFactoryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SchedulerNGFactoryFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.scheduler.DefaultSchedulerFactory;
 import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
+import org.apache.flink.runtime.scheduler.declarative.DeclarativeSchedulerFactory;
 
 /** Factory for {@link SchedulerNGFactory}. */
 public final class SchedulerNGFactoryFactory {
@@ -37,6 +38,8 @@ public final class SchedulerNGFactoryFactory {
         switch (schedulerName) {
             case SCHEDULER_TYPE_NG:
                 return new DefaultSchedulerFactory();
+            case DECLARATIVE_SCHEDULER:
+                return new DeclarativeSchedulerFactory();
 
             default:
                 throw new IllegalArgumentException(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SchedulerNGFactoryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SchedulerNGFactoryFactory.java
@@ -28,24 +28,22 @@ import org.apache.flink.runtime.scheduler.declarative.DeclarativeSchedulerFactor
 /** Factory for {@link SchedulerNGFactory}. */
 public final class SchedulerNGFactoryFactory {
 
-    public static final String SCHEDULER_TYPE_NG = "ng";
-    public static final String DECLARATIVE_SCHEDULER = "declarative";
-
     private SchedulerNGFactoryFactory() {}
 
     public static SchedulerNGFactory createSchedulerNGFactory(final Configuration configuration) {
-        final String schedulerName = configuration.getString(JobManagerOptions.SCHEDULER);
-        switch (schedulerName) {
-            case SCHEDULER_TYPE_NG:
+        final JobManagerOptions.SchedulerType schedulerTyp =
+                configuration.get(JobManagerOptions.SCHEDULER);
+        switch (schedulerTyp) {
+            case Ng:
                 return new DefaultSchedulerFactory();
-            case DECLARATIVE_SCHEDULER:
+            case Declarative:
                 return new DeclarativeSchedulerFactory();
 
             default:
                 throw new IllegalArgumentException(
                         String.format(
                                 "Illegal value [%s] for config option [%s]",
-                                schedulerName, JobManagerOptions.SCHEDULER.key()));
+                                schedulerTyp, JobManagerOptions.SCHEDULER.key()));
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -1227,6 +1227,8 @@ public class ExecutionGraph implements AccessExecutionGraph {
     }
 
     private void onTerminalState(JobStatus status) {
+        LOG.debug("ExecutionGraph {} reached terminal state {}.", getJobID(), status);
+
         try {
             CheckpointCoordinator coord = this.checkpointCoordinator;
             this.checkpointCoordinator = null;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -52,8 +52,8 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobmanager.OnCompletionActions;
 import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
 import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolService;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolServiceFactory;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -157,7 +157,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
 
     private final ClassLoader userCodeLoader;
 
-    private final SlotPool slotPool;
+    private final SlotPoolService slotPoolService;
 
     private final SchedulerNGFactory schedulerNGFactory;
 
@@ -219,7 +219,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
             ResourceID resourceId,
             JobGraph jobGraph,
             HighAvailabilityServices highAvailabilityService,
-            SlotPoolFactory slotPoolFactory,
+            SlotPoolServiceFactory slotPoolFactory,
             JobManagerSharedServices jobManagerSharedServices,
             HeartbeatServices heartbeatServices,
             JobManagerJobMetricGroupFactory jobMetricGroupFactory,
@@ -304,7 +304,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
         resourceManagerLeaderRetriever =
                 highAvailabilityServices.getResourceManagerLeaderRetriever();
 
-        this.slotPool = checkNotNull(slotPoolFactory).createSlotPool(jid);
+        this.slotPoolService = checkNotNull(slotPoolFactory).createSlotPoolService(jid);
 
         this.registeredTaskManagers = new HashMap<>(4);
         this.partitionTracker =
@@ -354,7 +354,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                         backPressureStatsTracker,
                         scheduledExecutorService,
                         jobMasterConfiguration.getConfiguration(),
-                        slotPool,
+                        slotPoolService,
                         scheduledExecutorService,
                         userCodeLoader,
                         highAvailabilityServices.getCheckpointRecoveryFactory(),
@@ -498,7 +498,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                 cause.getMessage());
 
         taskManagerHeartbeatManager.unmonitorTarget(resourceID);
-        slotPool.releaseTaskManager(resourceID, cause);
+        slotPoolService.releaseTaskManager(resourceID, cause);
         partitionTracker.stopTrackingPartitionsFor(resourceID);
 
         Tuple2<TaskManagerLocation, TaskExecutorGateway> taskManagerConnection =
@@ -616,7 +616,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                 new RpcTaskManagerGateway(taskExecutorGateway, getFencingToken());
 
         return CompletableFuture.completedFuture(
-                slotPool.offerSlots(taskManagerLocation, rpcTaskManagerGateway, slots));
+                slotPoolService.offerSlots(taskManagerLocation, rpcTaskManagerGateway, slots));
     }
 
     @Override
@@ -640,7 +640,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
     private void internalFailAllocation(
             @Nullable ResourceID resourceId, AllocationID allocationId, Exception cause) {
         final Optional<ResourceID> resourceIdOptional =
-                slotPool.failAllocation(resourceId, allocationId, cause);
+                slotPoolService.failAllocation(resourceId, allocationId, cause);
         resourceIdOptional.ifPresent(
                 taskManagerId -> {
                     if (!partitionTracker.isTrackingPartitionsFor(taskManagerId)) {
@@ -699,7 +699,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                                     return new RegistrationResponse.Decline(throwable.getMessage());
                                 }
 
-                                slotPool.registerTaskManager(taskManagerId);
+                                slotPoolService.registerTaskManager(taskManagerId);
                                 registeredTaskManagers.put(
                                         taskManagerId,
                                         Tuple2.of(taskManagerLocation, taskExecutorGateway));
@@ -809,7 +809,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
     @Override
     public void notifyNotEnoughResourcesAvailable(
             Collection<ResourceRequirement> acquiredResources) {
-        slotPool.notifyNotEnoughResourcesAvailable(acquiredResources);
+        slotPoolService.notifyNotEnoughResourcesAvailable(acquiredResources);
     }
 
     @Override
@@ -876,7 +876,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                     createResourceManagerHeartbeatManager(heartbeatServices);
 
             // start the slot pool make sure the slot pool now accepts messages for this leader
-            slotPool.start(getFencingToken(), getAddress(), getMainThreadExecutor());
+            slotPoolService.start(getFencingToken(), getAddress(), getMainThreadExecutor());
 
             // job is ready to go, try to establish connection with resource manager
             //   - activate leader retrieval for the resource manager
@@ -909,7 +909,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
 
         // TODO: Distinguish between job termination which should free all slots and a loss of
         // leadership which should keep the slots
-        slotPool.close();
+        slotPoolService.close();
 
         stopHeartbeatServices();
 
@@ -1076,7 +1076,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                     new EstablishedResourceManagerConnection(
                             resourceManagerGateway, resourceManagerResourceId);
 
-            slotPool.connectToResourceManager(resourceManagerGateway);
+            slotPoolService.connectToResourceManager(resourceManagerGateway);
 
             resourceManagerHeartbeatManager.monitorTarget(
                     resourceManagerResourceId,
@@ -1134,7 +1134,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
         ResourceManagerGateway resourceManagerGateway =
                 establishedResourceManagerConnection.getResourceManagerGateway();
         resourceManagerGateway.disconnectJobManager(jobGraph.getJobID(), cause);
-        slotPool.disconnectResourceManager();
+        slotPoolService.disconnectResourceManager();
     }
 
     // ----------------------------------------------------------------------------------------------
@@ -1302,7 +1302,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
         @Override
         public AllocatedSlotReport retrievePayload(ResourceID resourceID) {
             validateRunsInMainThread();
-            return slotPool.createAllocatedSlotReport(resourceID);
+            return slotPoolService.createAllocatedSlotReport(resourceID);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
@@ -30,7 +30,7 @@ import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.jobmaster.JobMasterConfiguration;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolServiceFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
@@ -41,7 +41,7 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
 
     private final JobMasterConfiguration jobMasterConfiguration;
 
-    private final SlotPoolFactory slotPoolFactory;
+    private final SlotPoolServiceFactory slotPoolFactory;
 
     private final RpcService rpcService;
 
@@ -61,7 +61,7 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
 
     public DefaultJobMasterServiceFactory(
             JobMasterConfiguration jobMasterConfiguration,
-            SlotPoolFactory slotPoolFactory,
+            SlotPoolServiceFactory slotPoolFactory,
             RpcService rpcService,
             HighAvailabilityServices haServices,
             JobManagerSharedServices jobManagerSharedServices,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AbstractSlotPoolServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AbstractSlotPoolServiceFactory.java
@@ -23,8 +23,8 @@ import org.apache.flink.util.clock.Clock;
 
 import javax.annotation.Nonnull;
 
-/** Abstract SlotPoolFactory. */
-public abstract class AbstractSlotPoolFactory implements SlotPoolFactory {
+/** Abstract SlotPoolServiceFactory. */
+public abstract class AbstractSlotPoolServiceFactory implements SlotPoolServiceFactory {
 
     @Nonnull protected final Clock clock;
 
@@ -34,7 +34,7 @@ public abstract class AbstractSlotPoolFactory implements SlotPoolFactory {
 
     @Nonnull protected final Time batchSlotTimeout;
 
-    protected AbstractSlotPoolFactory(
+    protected AbstractSlotPoolServiceFactory(
             @Nonnull Clock clock,
             @Nonnull Time rpcTimeout,
             @Nonnull Time slotIdleTimeout,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
@@ -66,7 +66,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /** {@link SlotPool} implementation which uses the {@link DeclarativeSlotPool} to allocate slots. */
-public class DeclarativeSlotPoolBridge implements SlotPool {
+public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
 
     private static final Logger LOG = LoggerFactory.getLogger(DeclarativeSlotPoolBridge.class);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeServiceFactory.java
@@ -25,9 +25,9 @@ import org.apache.flink.util.clock.Clock;
 import javax.annotation.Nonnull;
 
 /** Factory for {@link DeclarativeSlotPoolBridge}. */
-public class DeclarativeSlotPoolBridgeFactory extends AbstractSlotPoolFactory {
+public class DeclarativeSlotPoolBridgeServiceFactory extends AbstractSlotPoolServiceFactory {
 
-    public DeclarativeSlotPoolBridgeFactory(
+    public DeclarativeSlotPoolBridgeServiceFactory(
             @Nonnull Clock clock,
             @Nonnull Time rpcTimeout,
             @Nonnull Time slotIdleTimeout,
@@ -37,7 +37,7 @@ public class DeclarativeSlotPoolBridgeFactory extends AbstractSlotPoolFactory {
 
     @Nonnull
     @Override
-    public SlotPool createSlotPool(@Nonnull JobID jobId) {
+    public SlotPoolService createSlotPoolService(@Nonnull JobID jobId) {
         return new DeclarativeSlotPoolBridge(
                 jobId,
                 new DefaultDeclarativeSlotPoolFactory(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolService.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.AllocatedSlotReport;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+/** {@link SlotPoolService} implementation for the {@link DeclarativeSlotPool}. */
+public class DeclarativeSlotPoolService implements SlotPoolService {
+
+    private final JobID jobId;
+
+    private final DeclarativeSlotPool declarativeSlotPool;
+
+    public DeclarativeSlotPoolService(JobID jobId, DeclarativeSlotPool declarativeSlotPool) {
+        this.jobId = jobId;
+        this.declarativeSlotPool = declarativeSlotPool;
+    }
+
+    @Override
+    public <T> Optional<T> castInto(Class<T> clazz) {
+        if (clazz.isAssignableFrom(declarativeSlotPool.getClass())) {
+            return Optional.of(clazz.cast(declarativeSlotPool));
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public void start(
+            JobMasterId fencingToken,
+            String address,
+            ComponentMainThreadExecutor mainThreadExecutor)
+            throws Exception {}
+
+    @Override
+    public void suspend() {}
+
+    @Override
+    public void close() {}
+
+    @Override
+    public Collection<SlotOffer> offerSlots(
+            TaskManagerLocation taskManagerLocation,
+            TaskManagerGateway taskManagerGateway,
+            Collection<SlotOffer> offers) {
+        return declarativeSlotPool.offerSlots(
+                offers, taskManagerLocation, taskManagerGateway, System.nanoTime());
+    }
+
+    @Override
+    public Optional<ResourceID> failAllocation(
+            @Nullable ResourceID resourceID, AllocationID allocationId, Exception cause) {
+        declarativeSlotPool.releaseSlot(allocationId, cause);
+
+        if (declarativeSlotPool.containsSlots(resourceID)) {
+            return Optional.empty();
+        } else {
+            return Optional.of(resourceID);
+        }
+    }
+
+    @Override
+    public boolean registerTaskManager(ResourceID taskManagerId) {
+        return false;
+    }
+
+    @Override
+    public boolean releaseTaskManager(ResourceID resourceID, Exception cause) {
+        return false;
+    }
+
+    @Override
+    public void connectToResourceManager(ResourceManagerGateway resourceManagerGateway) {}
+
+    @Override
+    public void disconnectResourceManager() {}
+
+    @Override
+    public AllocatedSlotReport createAllocatedSlotReport(ResourceID resourceID) {
+        return new AllocatedSlotReport(jobId, Collections.emptyList());
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolServiceFactory.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.slots.ResourceRequirements;
 
 import javax.annotation.Nonnull;
 
@@ -38,24 +37,6 @@ public class DeclarativeSlotPoolServiceFactory implements SlotPoolServiceFactory
     @Nonnull
     @Override
     public SlotPoolService createSlotPoolService(@Nonnull JobID jobId) {
-        final DeclareResourceRequirementServiceConnectionManager
-                resourceRequirementServiceConnectionManager =
-                        DefaultDeclareResourceRequirementServiceConnectionManager.create(null);
-
-        final DeclarativeSlotPool declarativeSlotPool =
-                new DefaultDeclarativeSlotPool(
-                        jobId,
-                        new DefaultAllocatedSlotPool(),
-                        requiredResources -> {
-                            final ResourceRequirements resourceRequirements =
-                                    ResourceRequirements.create(jobId, null, requiredResources);
-                            resourceRequirementServiceConnectionManager.declareResourceRequirements(
-                                    resourceRequirements);
-                        },
-                        idleSlotTimeout,
-                        rpcTimeout);
-
-        return new DeclarativeSlotPoolService(
-                jobId, declarativeSlotPool, resourceRequirementServiceConnectionManager);
+        return new DeclarativeSlotPoolService(jobId, idleSlotTimeout, rpcTimeout);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolServiceFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+
+import javax.annotation.Nonnull;
+
+/** Factory for the {@link DeclarativeSlotPoolService}. */
+public class DeclarativeSlotPoolServiceFactory implements SlotPoolServiceFactory {
+
+    private final Time idleSlotTimeout;
+    private final Time rpcTimeout;
+
+    public DeclarativeSlotPoolServiceFactory(Time idleSlotTimeout, Time rpcTimeout) {
+        this.idleSlotTimeout = idleSlotTimeout;
+        this.rpcTimeout = rpcTimeout;
+    }
+
+    @Nonnull
+    @Override
+    public SlotPoolService createSlotPoolService(@Nonnull JobID jobId) {
+        final DeclarativeSlotPool declarativeSlotPool =
+                new DefaultDeclarativeSlotPool(
+                        jobId,
+                        new DefaultAllocatedSlotPool(),
+                        ignored -> {},
+                        idleSlotTimeout,
+                        rpcTimeout);
+        return new DeclarativeSlotPoolService(jobId, declarativeSlotPool);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultSlotPoolServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultSlotPoolServiceFactory.java
@@ -25,9 +25,9 @@ import org.apache.flink.util.clock.Clock;
 import javax.annotation.Nonnull;
 
 /** Default slot pool factory. */
-public class DefaultSlotPoolFactory extends AbstractSlotPoolFactory {
+public class DefaultSlotPoolServiceFactory extends AbstractSlotPoolServiceFactory {
 
-    public DefaultSlotPoolFactory(
+    public DefaultSlotPoolServiceFactory(
             @Nonnull Clock clock,
             @Nonnull Time rpcTimeout,
             @Nonnull Time slotIdleTimeout,
@@ -37,7 +37,7 @@ public class DefaultSlotPoolFactory extends AbstractSlotPoolFactory {
 
     @Override
     @Nonnull
-    public SlotPool createSlotPool(@Nonnull JobID jobId) {
+    public SlotPoolService createSlotPoolService(@Nonnull JobID jobId) {
         return new SlotPoolImpl(jobId, clock, rpcTimeout, slotIdleTimeout, batchSlotTimeout);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/ResourceCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/ResourceCounter.java
@@ -33,7 +33,7 @@ import java.util.Set;
  * <p>ResourceCounter contains a set of {@link ResourceProfile ResourceProfiles} and their
  * associated counts. The counts are always positive (> 0).
  */
-final class ResourceCounter {
+public final class ResourceCounter {
 
     private final Map<ResourceProfile, Integer> resources;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
-import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
@@ -123,11 +122,6 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
      */
     Optional<ResourceID> failAllocation(AllocationID allocationID, Exception cause);
 
-    default Optional<ResourceID> failAllocation(
-            @Nullable ResourceID resourceId, AllocationID allocationID, Exception cause) {
-        return failAllocation(allocationID, cause);
-    }
-
     // ------------------------------------------------------------------------
     //  allocating and disposing slots
     // ------------------------------------------------------------------------
@@ -197,14 +191,6 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
     @Nonnull
     CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(
             @Nonnull SlotRequestId slotRequestId, @Nonnull ResourceProfile resourceProfile);
-
-    /**
-     * Notifies that not enough resources are available to fulfill the resource requirements.
-     *
-     * @param acquiredResources the resources that have been acquired
-     */
-    default void notifyNotEnoughResourcesAvailable(
-            Collection<ResourceRequirement> acquiredResources) {}
 
     /**
      * Disables batch slot request timeout check. Invoked when someone else wants to take over the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
@@ -90,7 +90,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>TODO : Make pending requests location preference aware TODO : Make pass location preferences
  * to ResourceManager when sending a slot request
  */
-public class SlotPoolImpl implements SlotPool {
+public class SlotPoolImpl implements SlotPool, SlotPoolService {
 
     protected final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -827,6 +827,12 @@ public class SlotPoolImpl implements SlotPool {
 
         // TODO: add some unit tests when the previous two are ready, the allocation may failed at
         // any phase
+    }
+
+    @Override
+    public Optional<ResourceID> failAllocation(
+            @Nullable ResourceID resourceId, AllocationID allocationID, Exception cause) {
+        return failAllocation(allocationID, cause);
     }
 
     private Optional<ResourceID> tryFailingAllocatedSlot(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolService.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.AllocatedSlotReport;
+import org.apache.flink.runtime.jobmaster.JobMaster;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/** Service used by the {@link JobMaster} to manage a slot pool. */
+public interface SlotPoolService extends AutoCloseable {
+
+    default <T> Optional<T> castInto(Class<T> clazz) {
+        if (clazz.isAssignableFrom(this.getClass())) {
+            return Optional.of(clazz.cast(this));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    void start(
+            JobMasterId fencingToken,
+            String address,
+            ComponentMainThreadExecutor mainThreadExecutor)
+            throws Exception;
+
+    void suspend();
+
+    void close();
+
+    Collection<SlotOffer> offerSlots(
+            TaskManagerLocation taskManagerLocation,
+            TaskManagerGateway taskManagerGateway,
+            Collection<SlotOffer> offers);
+
+    Optional<ResourceID> failAllocation(
+            @Nullable ResourceID resourceID, AllocationID allocationId, Exception cause);
+
+    boolean registerTaskManager(ResourceID taskManagerId);
+
+    boolean releaseTaskManager(ResourceID resourceID, Exception cause);
+
+    void connectToResourceManager(ResourceManagerGateway resourceManagerGateway);
+
+    void disconnectResourceManager();
+
+    AllocatedSlotReport createAllocatedSlotReport(ResourceID resourceID);
+
+    /**
+     * Notifies that not enough resources are available to fulfill the resource requirements.
+     *
+     * @param acquiredResources the resources that have been acquired
+     */
+    default void notifyNotEnoughResourcesAvailable(
+            Collection<ResourceRequirement> acquiredResources) {}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolServiceFactory.java
@@ -28,13 +28,13 @@ import org.apache.flink.util.clock.SystemClock;
 
 import javax.annotation.Nonnull;
 
-/** Factory interface for {@link SlotPool}. */
-public interface SlotPoolFactory {
+/** Factory interface for {@link SlotPoolService}. */
+public interface SlotPoolServiceFactory {
 
     @Nonnull
-    SlotPool createSlotPool(@Nonnull JobID jobId);
+    SlotPoolService createSlotPoolService(@Nonnull JobID jobId);
 
-    static SlotPoolFactory fromConfiguration(Configuration configuration) {
+    static SlotPoolServiceFactory fromConfiguration(Configuration configuration) {
         final Time rpcTimeout = AkkaUtils.getTimeoutAsTime(configuration);
         final Time slotIdleTimeout =
                 Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_IDLE_TIMEOUT));
@@ -43,10 +43,10 @@ public interface SlotPoolFactory {
 
         if (ClusterOptions.isDeclarativeResourceManagementEnabled(configuration)) {
 
-            return new DeclarativeSlotPoolBridgeFactory(
+            return new DeclarativeSlotPoolBridgeServiceFactory(
                     SystemClock.getInstance(), rpcTimeout, slotIdleTimeout, batchSlotTimeout);
         } else {
-            return new DefaultSlotPoolFactory(
+            return new DefaultSlotPoolServiceFactory(
                     SystemClock.getInstance(), rpcTimeout, slotIdleTimeout, batchSlotTimeout);
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolServiceFactory.java
@@ -44,10 +44,13 @@ public interface SlotPoolServiceFactory {
         final boolean isDeclarativeSchedulerEnabled = isDeclarativeSchedulerEnabled(configuration);
 
         if (ClusterOptions.isDeclarativeResourceManagementEnabled(configuration)) {
+            if (isDeclarativeSchedulerEnabled) {
+                return new DeclarativeSlotPoolServiceFactory(slotIdleTimeout, rpcTimeout);
+            }
+
             return new DeclarativeSlotPoolBridgeServiceFactory(
                     SystemClock.getInstance(), rpcTimeout, slotIdleTimeout, batchSlotTimeout);
-        } else if (isDeclarativeSchedulerEnabled) {
-            return new DeclarativeSlotPoolServiceFactory(slotIdleTimeout, rpcTimeout);
+
         } else {
             return new DefaultSlotPoolServiceFactory(
                     SystemClock.getInstance(), rpcTimeout, slotIdleTimeout, batchSlotTimeout);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolServiceFactory.java
@@ -40,7 +40,8 @@ public interface SlotPoolServiceFactory {
                 Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_IDLE_TIMEOUT));
         final Time batchSlotTimeout =
                 Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT));
-        final boolean isDeclarativeSchedulerEnabled = isDeclarativeSchedulerEnabled(configuration);
+        final boolean isDeclarativeSchedulerEnabled =
+                ClusterOptions.isDeclarativeSchedulerEnabled(configuration);
 
         if (ClusterOptions.isDeclarativeResourceManagementEnabled(configuration)) {
             if (isDeclarativeSchedulerEnabled) {
@@ -54,10 +55,5 @@ public interface SlotPoolServiceFactory {
             return new DefaultSlotPoolServiceFactory(
                     SystemClock.getInstance(), rpcTimeout, slotIdleTimeout, batchSlotTimeout);
         }
-    }
-
-    static boolean isDeclarativeSchedulerEnabled(Configuration configuration) {
-        return configuration.get(JobManagerOptions.SCHEDULER)
-                == JobManagerOptions.SchedulerType.Declarative;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolServiceFactory.java
@@ -24,7 +24,6 @@ import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.dispatcher.SchedulerNGFactoryFactory;
 import org.apache.flink.util.clock.SystemClock;
 
 import javax.annotation.Nonnull;
@@ -58,8 +57,7 @@ public interface SlotPoolServiceFactory {
     }
 
     static boolean isDeclarativeSchedulerEnabled(Configuration configuration) {
-        return configuration
-                .get(JobManagerOptions.SCHEDULER)
-                .equals(SchedulerNGFactoryFactory.DECLARATIVE_SCHEDULER);
+        return configuration.get(JobManagerOptions.SCHEDULER)
+                == JobManagerOptions.SchedulerType.Declarative;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -25,7 +25,6 @@ import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.scheduler.SchedulerNG;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -141,13 +140,8 @@ public class OperatorCoordinatorHolder
         this.operatorMaxParallelism = operatorMaxParallelism;
     }
 
-    public void lazyInitialize(
-            SchedulerNG scheduler, ComponentMainThreadExecutor mainThreadExecutor) {
-        lazyInitialize(scheduler::handleGlobalFailure, mainThreadExecutor);
-    }
-
     @VisibleForTesting
-    void lazyInitialize(
+    public void lazyInitialize(
             Consumer<Throwable> globalFailureHandler,
             ComponentMainThreadExecutor mainThreadExecutor) {
         this.globalFailureHandler = globalFailureHandler;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolService;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
@@ -52,7 +53,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
             final BackPressureStatsTracker backPressureStatsTracker,
             final Executor ioExecutor,
             final Configuration jobMasterConfiguration,
-            final SlotPool slotPool,
+            final SlotPoolService slotPoolService,
             final ScheduledExecutorService futureExecutor,
             final ClassLoader userCodeLoader,
             final CheckpointRecoveryFactory checkpointRecoveryFactory,
@@ -65,6 +66,14 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
             final ExecutionDeploymentTracker executionDeploymentTracker,
             long initializationTimestamp)
             throws Exception {
+
+        final SlotPool slotPool =
+                slotPoolService
+                        .castInto(SlotPool.class)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "The DefaultScheduler requires a SlotPool."));
 
         final DefaultSchedulerComponents schedulerComponents =
                 createSchedulerComponents(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionGraphHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionGraphHandler.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.core.io.InputSplit;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
+import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.IntermediateResult;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
+import org.apache.flink.runtime.jobmaster.SerializedInputSplit;
+import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
+import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.InstantiationUtil;
+
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+
+/** Handler for the {@link ExecutionGraph} which offers some common operations. */
+public class ExecutionGraphHandler {
+
+    private final ExecutionGraph executionGraph;
+
+    private final BackPressureStatsTracker backPressureStatsTracker;
+
+    private final Logger log;
+
+    private final Executor ioExecutor;
+
+    public ExecutionGraphHandler(
+            ExecutionGraph executionGraph,
+            BackPressureStatsTracker backPressureStatsTracker,
+            Logger log,
+            Executor ioExecutor) {
+        this.executionGraph = executionGraph;
+        this.backPressureStatsTracker = backPressureStatsTracker;
+        this.log = log;
+        this.ioExecutor = ioExecutor;
+    }
+
+    public void acknowledgeCheckpoint(
+            final JobID jobID,
+            final ExecutionAttemptID executionAttemptID,
+            final long checkpointId,
+            final CheckpointMetrics checkpointMetrics,
+            final TaskStateSnapshot checkpointState) {
+
+        final CheckpointCoordinator checkpointCoordinator =
+                executionGraph.getCheckpointCoordinator();
+        final AcknowledgeCheckpoint ackMessage =
+                new AcknowledgeCheckpoint(
+                        jobID,
+                        executionAttemptID,
+                        checkpointId,
+                        checkpointMetrics,
+                        checkpointState);
+
+        final String taskManagerLocationInfo = retrieveTaskManagerLocation(executionAttemptID);
+
+        if (checkpointCoordinator != null) {
+            ioExecutor.execute(
+                    () -> {
+                        try {
+                            checkpointCoordinator.receiveAcknowledgeMessage(
+                                    ackMessage, taskManagerLocationInfo);
+                        } catch (Throwable t) {
+                            log.warn(
+                                    "Error while processing checkpoint acknowledgement message", t);
+                        }
+                    });
+        } else {
+            String errorMessage =
+                    "Received AcknowledgeCheckpoint message for job {} with no CheckpointCoordinator";
+            if (executionGraph.getState() == JobStatus.RUNNING) {
+                log.error(errorMessage, executionGraph.getJobID());
+            } else {
+                log.debug(errorMessage, executionGraph.getJobID());
+            }
+        }
+    }
+
+    public void declineCheckpoint(final DeclineCheckpoint decline) {
+
+        final CheckpointCoordinator checkpointCoordinator =
+                executionGraph.getCheckpointCoordinator();
+        final String taskManagerLocationInfo =
+                retrieveTaskManagerLocation(decline.getTaskExecutionId());
+
+        if (checkpointCoordinator != null) {
+            ioExecutor.execute(
+                    () -> {
+                        try {
+                            checkpointCoordinator.receiveDeclineMessage(
+                                    decline, taskManagerLocationInfo);
+                        } catch (Exception e) {
+                            log.error(
+                                    "Error in CheckpointCoordinator while processing {}",
+                                    decline,
+                                    e);
+                        }
+                    });
+        } else {
+            String errorMessage =
+                    "Received DeclineCheckpoint message for job {} with no CheckpointCoordinator";
+            if (executionGraph.getState() == JobStatus.RUNNING) {
+                log.error(errorMessage, executionGraph.getJobID());
+            } else {
+                log.debug(errorMessage, executionGraph.getJobID());
+            }
+        }
+    }
+
+    private String retrieveTaskManagerLocation(ExecutionAttemptID executionAttemptID) {
+        final Optional<Execution> currentExecution =
+                Optional.ofNullable(
+                        executionGraph.getRegisteredExecutions().get(executionAttemptID));
+
+        return currentExecution
+                .map(Execution::getAssignedResourceLocation)
+                .map(TaskManagerLocation::toString)
+                .orElse("Unknown location");
+    }
+
+    public Optional<OperatorBackPressureStats> requestOperatorBackPressureStats(
+            final JobVertexID jobVertexId) throws FlinkException {
+        final ExecutionJobVertex jobVertex = executionGraph.getJobVertex(jobVertexId);
+        if (jobVertex == null) {
+            throw new FlinkException("JobVertexID not found " + jobVertexId);
+        }
+
+        return backPressureStatsTracker.getOperatorBackPressureStats(jobVertex);
+    }
+
+    public ExecutionState requestPartitionState(
+            final IntermediateDataSetID intermediateResultId,
+            final ResultPartitionID resultPartitionId)
+            throws PartitionProducerDisposedException {
+
+        final Execution execution =
+                executionGraph.getRegisteredExecutions().get(resultPartitionId.getProducerId());
+        if (execution != null) {
+            return execution.getState();
+        } else {
+            final IntermediateResult intermediateResult =
+                    executionGraph.getAllIntermediateResults().get(intermediateResultId);
+
+            if (intermediateResult != null) {
+                // Try to find the producing execution
+                Execution producerExecution =
+                        intermediateResult
+                                .getPartitionById(resultPartitionId.getPartitionId())
+                                .getProducer()
+                                .getCurrentExecutionAttempt();
+
+                if (producerExecution.getAttemptId().equals(resultPartitionId.getProducerId())) {
+                    return producerExecution.getState();
+                } else {
+                    throw new PartitionProducerDisposedException(resultPartitionId);
+                }
+            } else {
+                throw new IllegalArgumentException(
+                        "Intermediate data set with ID " + intermediateResultId + " not found.");
+            }
+        }
+    }
+
+    public SerializedInputSplit requestNextInputSplit(
+            JobVertexID vertexID, ExecutionAttemptID executionAttempt) throws IOException {
+
+        final Execution execution = executionGraph.getRegisteredExecutions().get(executionAttempt);
+        if (execution == null) {
+            // can happen when JobManager had already unregistered this execution upon on task
+            // failure,
+            // but TaskManager get some delay to aware of that situation
+            if (log.isDebugEnabled()) {
+                log.debug("Can not find Execution for attempt {}.", executionAttempt);
+            }
+            // but we should TaskManager be aware of this
+            throw new IllegalArgumentException(
+                    "Can not find Execution for attempt " + executionAttempt);
+        }
+
+        final ExecutionJobVertex vertex = executionGraph.getJobVertex(vertexID);
+        if (vertex == null) {
+            throw new IllegalArgumentException(
+                    "Cannot find execution vertex for vertex ID " + vertexID);
+        }
+
+        if (vertex.getSplitAssigner() == null) {
+            throw new IllegalStateException("No InputSplitAssigner for vertex ID " + vertexID);
+        }
+
+        final InputSplit nextInputSplit = execution.getNextInputSplit();
+
+        if (log.isDebugEnabled()) {
+            log.debug("Send next input split {}.", nextInputSplit);
+        }
+
+        try {
+            final byte[] serializedInputSplit = InstantiationUtil.serializeObject(nextInputSplit);
+            return new SerializedInputSplit(serializedInputSplit);
+        } catch (Exception ex) {
+            IOException reason =
+                    new IOException(
+                            "Could not serialize the next input split of class "
+                                    + nextInputSplit.getClass()
+                                    + ".",
+                            ex);
+            vertex.fail(reason);
+            throw reason;
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotSharingGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotSharingGroup.java
@@ -25,7 +25,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /** Represents execution vertices that will run the same shared slot. */
-class ExecutionSlotSharingGroup {
+public class ExecutionSlotSharingGroup {
 
     private final Set<ExecutionVertexID> executionVertexIds;
 
@@ -39,5 +39,14 @@ class ExecutionSlotSharingGroup {
 
     Set<ExecutionVertexID> getExecutionVertexIds() {
         return Collections.unmodifiableSet(executionVertexIds);
+    }
+
+    public static ExecutionSlotSharingGroup forVertexIds(
+            Set<ExecutionVertexID> executionVertexIds) {
+        final ExecutionSlotSharingGroup executionSlotSharingGroup = new ExecutionSlotSharingGroup();
+        for (ExecutionVertexID executionVertexId : executionVertexIds) {
+            executionSlotSharingGroup.addVertex(executionVertexId);
+        }
+        return executionSlotSharingGroup;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/KvStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/KvStateHandler.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.queryablestate.KvStateID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.query.KvStateLocation;
+import org.apache.flink.runtime.query.KvStateLocationRegistry;
+import org.apache.flink.runtime.query.UnknownKvStateLocation;
+import org.apache.flink.runtime.state.KeyGroupRange;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+
+/** Handler for common queryable state logic. */
+public class KvStateHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KvStateHandler.class);
+
+    private final ExecutionGraph executionGraph;
+
+    public KvStateHandler(ExecutionGraph executionGraph) {
+        this.executionGraph = executionGraph;
+    }
+
+    public KvStateLocation requestKvStateLocation(final JobID jobId, final String registrationName)
+            throws UnknownKvStateLocation, FlinkJobNotFoundException {
+
+        // sanity check for the correct JobID
+        if (executionGraph.getJobID().equals(jobId)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "Lookup key-value state for job {} with registration " + "name {}.",
+                        executionGraph.getJobID(),
+                        registrationName);
+            }
+
+            final KvStateLocationRegistry registry = executionGraph.getKvStateLocationRegistry();
+            final KvStateLocation location = registry.getKvStateLocation(registrationName);
+            if (location != null) {
+                return location;
+            } else {
+                throw new UnknownKvStateLocation(registrationName);
+            }
+        } else {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "Request of key-value state location for unknown job {} received.", jobId);
+            }
+            throw new FlinkJobNotFoundException(jobId);
+        }
+    }
+
+    public void notifyKvStateRegistered(
+            final JobID jobId,
+            final JobVertexID jobVertexId,
+            final KeyGroupRange keyGroupRange,
+            final String registrationName,
+            final KvStateID kvStateId,
+            final InetSocketAddress kvStateServerAddress)
+            throws FlinkJobNotFoundException {
+
+        if (executionGraph.getJobID().equals(jobId)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "Key value state registered for job {} under name {}.",
+                        executionGraph.getJobID(),
+                        registrationName);
+            }
+
+            try {
+                executionGraph
+                        .getKvStateLocationRegistry()
+                        .notifyKvStateRegistered(
+                                jobVertexId,
+                                keyGroupRange,
+                                registrationName,
+                                kvStateId,
+                                kvStateServerAddress);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            throw new FlinkJobNotFoundException(jobId);
+        }
+    }
+
+    public void notifyKvStateUnregistered(
+            final JobID jobId,
+            final JobVertexID jobVertexId,
+            final KeyGroupRange keyGroupRange,
+            final String registrationName)
+            throws FlinkJobNotFoundException {
+
+        if (executionGraph.getJobID().equals(jobId)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "Key value state unregistered for job {} under name {}.",
+                        executionGraph.getJobID(),
+                        registrationName);
+            }
+
+            try {
+                executionGraph
+                        .getKvStateLocationRegistry()
+                        .notifyKvStateUnregistered(jobVertexId, keyGroupRange, registrationName);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            throw new FlinkJobNotFoundException(jobId);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/OperatorCoordinatorHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/OperatorCoordinatorHandler.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequestHandler;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinatorHolder;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.runtime.operators.coordination.TaskNotRunningException;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.IOUtils;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+/** Handler for the {@link OperatorCoordinator OperatorCoordinators}. */
+public class OperatorCoordinatorHandler {
+    private final ExecutionGraph executionGraph;
+
+    private final Map<OperatorID, OperatorCoordinatorHolder> coordinatorMap;
+
+    private final Consumer<Throwable> globalFailureHandler;
+
+    public OperatorCoordinatorHandler(
+            ExecutionGraph executionGraph, Consumer<Throwable> globalFailureHandler) {
+        this.executionGraph = executionGraph;
+
+        this.coordinatorMap = createCoordinatorMap(executionGraph);
+        this.globalFailureHandler = globalFailureHandler;
+    }
+
+    private Map<OperatorID, OperatorCoordinatorHolder> createCoordinatorMap(
+            ExecutionGraph executionGraph) {
+        Map<OperatorID, OperatorCoordinatorHolder> coordinatorMap = new HashMap<>();
+        for (ExecutionJobVertex vertex : executionGraph.getAllVertices().values()) {
+            for (OperatorCoordinatorHolder holder : vertex.getOperatorCoordinators()) {
+                coordinatorMap.put(holder.operatorId(), holder);
+            }
+        }
+        return coordinatorMap;
+    }
+
+    public void initializeOperatorCoordinators(ComponentMainThreadExecutor mainThreadExecutor) {
+        for (OperatorCoordinatorHolder coordinatorHolder : coordinatorMap.values()) {
+            coordinatorHolder.lazyInitialize(globalFailureHandler, mainThreadExecutor);
+        }
+    }
+
+    public void startAllOperatorCoordinators() {
+        final Collection<OperatorCoordinatorHolder> coordinators = coordinatorMap.values();
+        try {
+            for (OperatorCoordinatorHolder coordinator : coordinators) {
+                coordinator.start();
+            }
+        } catch (Throwable t) {
+            ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
+            coordinators.forEach(IOUtils::closeQuietly);
+            throw new FlinkRuntimeException("Failed to start the operator coordinators", t);
+        }
+    }
+
+    public void disposeAllOperatorCoordinators() {
+        coordinatorMap.values().forEach(IOUtils::closeQuietly);
+    }
+
+    public void deliverOperatorEventToCoordinator(
+            final ExecutionAttemptID taskExecutionId,
+            final OperatorID operatorId,
+            final OperatorEvent evt)
+            throws FlinkException {
+
+        // Failure semantics (as per the javadocs of the method):
+        // If the task manager sends an event for a non-running task or an non-existing operator
+        // coordinator, then respond with an exception to the call. If task and coordinator exist,
+        // then we assume that the call from the TaskManager was valid, and any bubbling exception
+        // needs to cause a job failure.
+
+        final Execution exec = executionGraph.getRegisteredExecutions().get(taskExecutionId);
+        if (exec == null || exec.getState() != ExecutionState.RUNNING) {
+            // This situation is common when cancellation happens, or when the task failed while the
+            // event was just being dispatched asynchronously on the TM side.
+            // It should be fine in those expected situations to just ignore this event, but, to be
+            // on the safe, we notify the TM that the event could not be delivered.
+            throw new TaskNotRunningException(
+                    "Task is not known or in state running on the JobManager.");
+        }
+
+        final OperatorCoordinatorHolder coordinator = coordinatorMap.get(operatorId);
+        if (coordinator == null) {
+            throw new FlinkException("No coordinator registered for operator " + operatorId);
+        }
+
+        try {
+            coordinator.handleEventFromOperator(exec.getParallelSubtaskIndex(), evt);
+        } catch (Throwable t) {
+            ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
+            globalFailureHandler.accept(t);
+        }
+    }
+
+    public CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
+            OperatorID operator, CoordinationRequest request) throws FlinkException {
+
+        final OperatorCoordinatorHolder coordinatorHolder = coordinatorMap.get(operator);
+        if (coordinatorHolder == null) {
+            throw new FlinkException("Coordinator of operator " + operator + " does not exist");
+        }
+
+        final OperatorCoordinator coordinator = coordinatorHolder.coordinator();
+        if (coordinator instanceof CoordinationRequestHandler) {
+            return ((CoordinationRequestHandler) coordinator).handleCoordinationRequest(request);
+        } else {
+            throw new FlinkException(
+                    "Coordinator of operator " + operator + " cannot handle client event");
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
@@ -53,7 +52,6 @@ import org.apache.flink.runtime.executiongraph.ExecutionGraphBuilder;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionStateUpdateListener;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
-import org.apache.flink.runtime.executiongraph.IntermediateResult;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
 import org.apache.flink.runtime.executiongraph.failover.flip1.ResultPartitionAvailabilityChecker;
@@ -72,7 +70,6 @@ import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTrackerDeploymentLi
 import org.apache.flink.runtime.jobmaster.SerializedInputSplit;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
-import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
 import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.metrics.MetricNames;
@@ -93,13 +90,11 @@ import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.state.KeyGroupRange;
-import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.util.IntArrayList;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
-import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.IterableUtils;
 import org.apache.flink.util.function.FunctionUtils;
 
@@ -172,6 +167,8 @@ public abstract class SchedulerBase implements SchedulerNG {
     protected final ExecutionVertexVersioner executionVertexVersioner;
 
     private final KvStateHandler kvStateHandler;
+
+    private final ExecutionGraphHandler executionGraphHandler;
 
     private final Map<OperatorID, OperatorCoordinatorHolder> coordinatorMap;
 
@@ -251,6 +248,9 @@ public abstract class SchedulerBase implements SchedulerNG {
                 new ExecutionGraphToInputsLocationsRetrieverAdapter(executionGraph);
 
         this.kvStateHandler = new KvStateHandler(executionGraph);
+        this.executionGraphHandler =
+                new ExecutionGraphHandler(
+                        executionGraph, backPressureStatsTracker, log, ioExecutor);
 
         this.coordinatorMap = createCoordinatorMap();
     }
@@ -733,48 +733,7 @@ public abstract class SchedulerBase implements SchedulerNG {
             JobVertexID vertexID, ExecutionAttemptID executionAttempt) throws IOException {
         mainThreadExecutor.assertRunningInMainThread();
 
-        final Execution execution = executionGraph.getRegisteredExecutions().get(executionAttempt);
-        if (execution == null) {
-            // can happen when JobManager had already unregistered this execution upon on task
-            // failure,
-            // but TaskManager get some delay to aware of that situation
-            if (log.isDebugEnabled()) {
-                log.debug("Can not find Execution for attempt {}.", executionAttempt);
-            }
-            // but we should TaskManager be aware of this
-            throw new IllegalArgumentException(
-                    "Can not find Execution for attempt " + executionAttempt);
-        }
-
-        final ExecutionJobVertex vertex = executionGraph.getJobVertex(vertexID);
-        if (vertex == null) {
-            throw new IllegalArgumentException(
-                    "Cannot find execution vertex for vertex ID " + vertexID);
-        }
-
-        if (vertex.getSplitAssigner() == null) {
-            throw new IllegalStateException("No InputSplitAssigner for vertex ID " + vertexID);
-        }
-
-        final InputSplit nextInputSplit = execution.getNextInputSplit();
-
-        if (log.isDebugEnabled()) {
-            log.debug("Send next input split {}.", nextInputSplit);
-        }
-
-        try {
-            final byte[] serializedInputSplit = InstantiationUtil.serializeObject(nextInputSplit);
-            return new SerializedInputSplit(serializedInputSplit);
-        } catch (Exception ex) {
-            IOException reason =
-                    new IOException(
-                            "Could not serialize the next input split of class "
-                                    + nextInputSplit.getClass()
-                                    + ".",
-                            ex);
-            vertex.fail(reason);
-            throw reason;
-        }
+        return executionGraphHandler.requestNextInputSplit(vertexID, executionAttempt);
     }
 
     @Override
@@ -785,32 +744,7 @@ public abstract class SchedulerBase implements SchedulerNG {
 
         mainThreadExecutor.assertRunningInMainThread();
 
-        final Execution execution =
-                executionGraph.getRegisteredExecutions().get(resultPartitionId.getProducerId());
-        if (execution != null) {
-            return execution.getState();
-        } else {
-            final IntermediateResult intermediateResult =
-                    executionGraph.getAllIntermediateResults().get(intermediateResultId);
-
-            if (intermediateResult != null) {
-                // Try to find the producing execution
-                Execution producerExecution =
-                        intermediateResult
-                                .getPartitionById(resultPartitionId.getPartitionId())
-                                .getProducer()
-                                .getCurrentExecutionAttempt();
-
-                if (producerExecution.getAttemptId().equals(resultPartitionId.getProducerId())) {
-                    return producerExecution.getState();
-                } else {
-                    throw new PartitionProducerDisposedException(resultPartitionId);
-                }
-            } else {
-                throw new IllegalArgumentException(
-                        "Intermediate data set with ID " + intermediateResultId + " not found.");
-            }
-        }
+        return executionGraphHandler.requestPartitionState(intermediateResultId, resultPartitionId);
     }
 
     @Override
@@ -893,12 +827,7 @@ public abstract class SchedulerBase implements SchedulerNG {
     @Override
     public Optional<OperatorBackPressureStats> requestOperatorBackPressureStats(
             final JobVertexID jobVertexId) throws FlinkException {
-        final ExecutionJobVertex jobVertex = executionGraph.getJobVertex(jobVertexId);
-        if (jobVertex == null) {
-            throw new FlinkException("JobVertexID not found " + jobVertexId);
-        }
-
-        return backPressureStatsTracker.getOperatorBackPressureStats(jobVertex);
+        return executionGraphHandler.requestOperatorBackPressureStats(jobVertexId);
     }
 
     @Override
@@ -977,71 +906,15 @@ public abstract class SchedulerBase implements SchedulerNG {
             final TaskStateSnapshot checkpointState) {
         mainThreadExecutor.assertRunningInMainThread();
 
-        final CheckpointCoordinator checkpointCoordinator =
-                executionGraph.getCheckpointCoordinator();
-        final AcknowledgeCheckpoint ackMessage =
-                new AcknowledgeCheckpoint(
-                        jobID,
-                        executionAttemptID,
-                        checkpointId,
-                        checkpointMetrics,
-                        checkpointState);
-
-        final String taskManagerLocationInfo = retrieveTaskManagerLocation(executionAttemptID);
-
-        if (checkpointCoordinator != null) {
-            ioExecutor.execute(
-                    () -> {
-                        try {
-                            checkpointCoordinator.receiveAcknowledgeMessage(
-                                    ackMessage, taskManagerLocationInfo);
-                        } catch (Throwable t) {
-                            log.warn(
-                                    "Error while processing checkpoint acknowledgement message", t);
-                        }
-                    });
-        } else {
-            String errorMessage =
-                    "Received AcknowledgeCheckpoint message for job {} with no CheckpointCoordinator";
-            if (executionGraph.getState() == JobStatus.RUNNING) {
-                log.error(errorMessage, jobGraph.getJobID());
-            } else {
-                log.debug(errorMessage, jobGraph.getJobID());
-            }
-        }
+        executionGraphHandler.acknowledgeCheckpoint(
+                jobID, executionAttemptID, checkpointId, checkpointMetrics, checkpointState);
     }
 
     @Override
     public void declineCheckpoint(final DeclineCheckpoint decline) {
         mainThreadExecutor.assertRunningInMainThread();
 
-        final CheckpointCoordinator checkpointCoordinator =
-                executionGraph.getCheckpointCoordinator();
-        final String taskManagerLocationInfo =
-                retrieveTaskManagerLocation(decline.getTaskExecutionId());
-
-        if (checkpointCoordinator != null) {
-            ioExecutor.execute(
-                    () -> {
-                        try {
-                            checkpointCoordinator.receiveDeclineMessage(
-                                    decline, taskManagerLocationInfo);
-                        } catch (Exception e) {
-                            log.error(
-                                    "Error in CheckpointCoordinator while processing {}",
-                                    decline,
-                                    e);
-                        }
-                    });
-        } else {
-            String errorMessage =
-                    "Received DeclineCheckpoint message for job {} with no CheckpointCoordinator";
-            if (executionGraph.getState() == JobStatus.RUNNING) {
-                log.error(errorMessage, jobGraph.getJobID());
-            } else {
-                log.debug(errorMessage, jobGraph.getJobID());
-            }
-        }
+        executionGraphHandler.declineCheckpoint(decline);
     }
 
     @Override
@@ -1124,17 +997,6 @@ public abstract class SchedulerBase implements SchedulerNG {
                             return path;
                         },
                         mainThreadExecutor);
-    }
-
-    private String retrieveTaskManagerLocation(ExecutionAttemptID executionAttemptID) {
-        final Optional<Execution> currentExecution =
-                Optional.ofNullable(
-                        executionGraph.getRegisteredExecutions().get(executionAttemptID));
-
-        return currentExecution
-                .map(Execution::getAssignedResourceLocation)
-                .map(TaskManagerLocation::toString)
-                .orElse("Unknown location");
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -75,12 +75,10 @@ import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
-import org.apache.flink.runtime.operators.coordination.CoordinationRequestHandler;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinatorHolder;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
-import org.apache.flink.runtime.operators.coordination.TaskNotRunningException;
 import org.apache.flink.runtime.query.KvStateLocation;
 import org.apache.flink.runtime.query.UnknownKvStateLocation;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
@@ -93,8 +91,6 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.util.IntArrayList;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.FlinkRuntimeException;
-import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.IterableUtils;
 import org.apache.flink.util.function.FunctionUtils;
 
@@ -170,7 +166,7 @@ public abstract class SchedulerBase implements SchedulerNG {
 
     private final ExecutionGraphHandler executionGraphHandler;
 
-    private final Map<OperatorID, OperatorCoordinatorHolder> coordinatorMap;
+    private final OperatorCoordinatorHandler operatorCoordinatorHandler;
 
     private ComponentMainThreadExecutor mainThreadExecutor =
             new ComponentMainThreadExecutor.DummyComponentMainThreadExecutor(
@@ -251,8 +247,8 @@ public abstract class SchedulerBase implements SchedulerNG {
         this.executionGraphHandler =
                 new ExecutionGraphHandler(
                         executionGraph, backPressureStatsTracker, log, ioExecutor);
-
-        this.coordinatorMap = createCoordinatorMap();
+        this.operatorCoordinatorHandler =
+                new OperatorCoordinatorHandler(executionGraph, this::handleGlobalFailure);
     }
 
     private void registerShutDownCheckpointServicesOnExecutionGraphTermination(
@@ -631,7 +627,7 @@ public abstract class SchedulerBase implements SchedulerNG {
     @Override
     public void initialize(final ComponentMainThreadExecutor mainThreadExecutor) {
         this.mainThreadExecutor = checkNotNull(mainThreadExecutor);
-        initializeOperatorCoordinators(mainThreadExecutor);
+        operatorCoordinatorHandler.initializeOperatorCoordinators(mainThreadExecutor);
         executionGraph.setInternalTaskFailuresListener(
                 new UpdateSchedulerNgOnInternalFailuresListener(this, jobGraph.getJobID()));
         executionGraph.start(mainThreadExecutor);
@@ -646,7 +642,7 @@ public abstract class SchedulerBase implements SchedulerNG {
     public final void startScheduling() {
         mainThreadExecutor.assertRunningInMainThread();
         registerJobMetrics();
-        startAllOperatorCoordinators();
+        operatorCoordinatorHandler.startAllOperatorCoordinators();
         startSchedulingInternal();
     }
 
@@ -663,7 +659,7 @@ public abstract class SchedulerBase implements SchedulerNG {
 
         incrementVersionsOfAllVertices();
         executionGraph.suspend(cause);
-        disposeAllOperatorCoordinators();
+        operatorCoordinatorHandler.disposeAllOperatorCoordinators();
     }
 
     @Override
@@ -1021,88 +1017,16 @@ public abstract class SchedulerBase implements SchedulerNG {
             final OperatorEvent evt)
             throws FlinkException {
 
-        // Failure semantics (as per the javadocs of the method):
-        // If the task manager sends an event for a non-running task or an non-existing operator
-        // coordinator, then respond with an exception to the call. If task and coordinator exist,
-        // then we assume that the call from the TaskManager was valid, and any bubbling exception
-        // needs to cause a job failure.
-
-        final Execution exec = executionGraph.getRegisteredExecutions().get(taskExecutionId);
-        if (exec == null || exec.getState() != ExecutionState.RUNNING) {
-            // This situation is common when cancellation happens, or when the task failed while the
-            // event was just being dispatched asynchronously on the TM side.
-            // It should be fine in those expected situations to just ignore this event, but, to be
-            // on the safe, we notify the TM that the event could not be delivered.
-            throw new TaskNotRunningException(
-                    "Task is not known or in state running on the JobManager.");
-        }
-
-        final OperatorCoordinatorHolder coordinator = coordinatorMap.get(operatorId);
-        if (coordinator == null) {
-            throw new FlinkException("No coordinator registered for operator " + operatorId);
-        }
-
-        try {
-            coordinator.handleEventFromOperator(exec.getParallelSubtaskIndex(), evt);
-        } catch (Throwable t) {
-            ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
-            handleGlobalFailure(t);
-        }
+        operatorCoordinatorHandler.deliverOperatorEventToCoordinator(
+                taskExecutionId, operatorId, evt);
     }
 
     @Override
     public CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
             OperatorID operator, CoordinationRequest request) throws FlinkException {
 
-        final OperatorCoordinatorHolder coordinatorHolder = coordinatorMap.get(operator);
-        if (coordinatorHolder == null) {
-            throw new FlinkException("Coordinator of operator " + operator + " does not exist");
-        }
-
-        final OperatorCoordinator coordinator = coordinatorHolder.coordinator();
-        if (coordinator instanceof CoordinationRequestHandler) {
-            return ((CoordinationRequestHandler) coordinator).handleCoordinationRequest(request);
-        } else {
-            throw new FlinkException(
-                    "Coordinator of operator " + operator + " cannot handle client event");
-        }
-    }
-
-    private void initializeOperatorCoordinators(ComponentMainThreadExecutor mainThreadExecutor) {
-        for (OperatorCoordinatorHolder coordinatorHolder : getAllCoordinators()) {
-            coordinatorHolder.lazyInitialize(this::handleGlobalFailure, mainThreadExecutor);
-        }
-    }
-
-    private void startAllOperatorCoordinators() {
-        final Collection<OperatorCoordinatorHolder> coordinators = getAllCoordinators();
-        try {
-            for (OperatorCoordinatorHolder coordinator : coordinators) {
-                coordinator.start();
-            }
-        } catch (Throwable t) {
-            ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
-            coordinators.forEach(IOUtils::closeQuietly);
-            throw new FlinkRuntimeException("Failed to start the operator coordinators", t);
-        }
-    }
-
-    private void disposeAllOperatorCoordinators() {
-        getAllCoordinators().forEach(IOUtils::closeQuietly);
-    }
-
-    private Collection<OperatorCoordinatorHolder> getAllCoordinators() {
-        return coordinatorMap.values();
-    }
-
-    private Map<OperatorID, OperatorCoordinatorHolder> createCoordinatorMap() {
-        Map<OperatorID, OperatorCoordinatorHolder> coordinatorMap = new HashMap<>();
-        for (ExecutionJobVertex vertex : executionGraph.getAllVertices().values()) {
-            for (OperatorCoordinatorHolder holder : vertex.getOperatorCoordinators()) {
-                coordinatorMap.put(holder.operatorId(), holder);
-            }
-        }
-        return coordinatorMap;
+        return operatorCoordinatorHandler.deliverCoordinationRequestToCoordinator(
+                operator, request);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -1070,7 +1070,7 @@ public abstract class SchedulerBase implements SchedulerNG {
 
     private void initializeOperatorCoordinators(ComponentMainThreadExecutor mainThreadExecutor) {
         for (OperatorCoordinatorHolder coordinatorHolder : getAllCoordinators()) {
-            coordinatorHolder.lazyInitialize(this, mainThreadExecutor);
+            coordinatorHolder.lazyInitialize(this::handleGlobalFailure, mainThreadExecutor);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -85,7 +85,6 @@ import org.apache.flink.runtime.operators.coordination.OperatorCoordinatorHolder
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.TaskNotRunningException;
 import org.apache.flink.runtime.query.KvStateLocation;
-import org.apache.flink.runtime.query.KvStateLocationRegistry;
 import org.apache.flink.runtime.query.UnknownKvStateLocation;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
@@ -172,6 +171,8 @@ public abstract class SchedulerBase implements SchedulerNG {
 
     protected final ExecutionVertexVersioner executionVertexVersioner;
 
+    private final KvStateHandler kvStateHandler;
+
     private final Map<OperatorID, OperatorCoordinatorHolder> coordinatorMap;
 
     private ComponentMainThreadExecutor mainThreadExecutor =
@@ -248,6 +249,8 @@ public abstract class SchedulerBase implements SchedulerNG {
                         getExecutionVertex(executionVertexId).getPreferredLocationBasedOnState();
         inputsLocationsRetriever =
                 new ExecutionGraphToInputsLocationsRetrieverAdapter(executionGraph);
+
+        this.kvStateHandler = new KvStateHandler(executionGraph);
 
         this.coordinatorMap = createCoordinatorMap();
     }
@@ -844,29 +847,7 @@ public abstract class SchedulerBase implements SchedulerNG {
             throws UnknownKvStateLocation, FlinkJobNotFoundException {
         mainThreadExecutor.assertRunningInMainThread();
 
-        // sanity check for the correct JobID
-        if (jobGraph.getJobID().equals(jobId)) {
-            if (log.isDebugEnabled()) {
-                log.debug(
-                        "Lookup key-value state for job {} with registration " + "name {}.",
-                        jobGraph.getJobID(),
-                        registrationName);
-            }
-
-            final KvStateLocationRegistry registry = executionGraph.getKvStateLocationRegistry();
-            final KvStateLocation location = registry.getKvStateLocation(registrationName);
-            if (location != null) {
-                return location;
-            } else {
-                throw new UnknownKvStateLocation(registrationName);
-            }
-        } else {
-            if (log.isDebugEnabled()) {
-                log.debug(
-                        "Request of key-value state location for unknown job {} received.", jobId);
-            }
-            throw new FlinkJobNotFoundException(jobId);
-        }
+        return kvStateHandler.requestKvStateLocation(jobId, registrationName);
     }
 
     @Override
@@ -880,29 +861,13 @@ public abstract class SchedulerBase implements SchedulerNG {
             throws FlinkJobNotFoundException {
         mainThreadExecutor.assertRunningInMainThread();
 
-        if (jobGraph.getJobID().equals(jobId)) {
-            if (log.isDebugEnabled()) {
-                log.debug(
-                        "Key value state registered for job {} under name {}.",
-                        jobGraph.getJobID(),
-                        registrationName);
-            }
-
-            try {
-                executionGraph
-                        .getKvStateLocationRegistry()
-                        .notifyKvStateRegistered(
-                                jobVertexId,
-                                keyGroupRange,
-                                registrationName,
-                                kvStateId,
-                                kvStateServerAddress);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        } else {
-            throw new FlinkJobNotFoundException(jobId);
-        }
+        kvStateHandler.notifyKvStateRegistered(
+                jobId,
+                jobVertexId,
+                keyGroupRange,
+                registrationName,
+                kvStateId,
+                kvStateServerAddress);
     }
 
     @Override
@@ -914,24 +879,8 @@ public abstract class SchedulerBase implements SchedulerNG {
             throws FlinkJobNotFoundException {
         mainThreadExecutor.assertRunningInMainThread();
 
-        if (jobGraph.getJobID().equals(jobId)) {
-            if (log.isDebugEnabled()) {
-                log.debug(
-                        "Key value state unregistered for job {} under name {}.",
-                        jobGraph.getJobID(),
-                        registrationName);
-            }
-
-            try {
-                executionGraph
-                        .getKvStateLocationRegistry()
-                        .notifyKvStateUnregistered(jobVertexId, keyGroupRange, registrationName);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        } else {
-            throw new FlinkJobNotFoundException(jobId);
-        }
+        kvStateHandler.notifyKvStateUnregistered(
+                jobId, jobVertexId, keyGroupRange, registrationName);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolService;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
@@ -45,7 +45,7 @@ public interface SchedulerNGFactory {
             BackPressureStatsTracker backPressureStatsTracker,
             Executor ioExecutor,
             Configuration jobMasterConfiguration,
-            SlotPool slotPool,
+            SlotPoolService slotPoolService,
             ScheduledExecutorService futureExecutor,
             ClassLoader userCodeLoader,
             CheckpointRecoveryFactory checkpointRecoveryFactory,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SharedSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SharedSlot.java
@@ -62,7 +62,7 @@ import java.util.stream.Collectors;
  * {@link SlotSharingExecutionSlotAllocator} to remove it from the allocator and cancel its
  * underlying physical slot request if the request is not fulfilled yet.
  */
-class SharedSlot implements SlotOwner, PhysicalSlot.Payload {
+public class SharedSlot implements SlotOwner, PhysicalSlot.Payload {
     private static final Logger LOG = LoggerFactory.getLogger(SharedSlot.class);
 
     private final SlotRequestId physicalSlotRequestId;
@@ -83,7 +83,7 @@ class SharedSlot implements SlotOwner, PhysicalSlot.Payload {
 
     private State state;
 
-    SharedSlot(
+    public SharedSlot(
             SlotRequestId physicalSlotRequestId,
             ResourceProfile physicalSlotResourceProfile,
             ExecutionSlotSharingGroup executionSlotSharingGroup,
@@ -134,7 +134,7 @@ class SharedSlot implements SlotOwner, PhysicalSlot.Payload {
      *     logical slot
      * @return the logical slot future
      */
-    CompletableFuture<LogicalSlot> allocateLogicalSlot(ExecutionVertexID executionVertexId) {
+    public CompletableFuture<LogicalSlot> allocateLogicalSlot(ExecutionVertexID executionVertexId) {
         Preconditions.checkArgument(
                 executionSlotSharingGroup.getExecutionVertexIds().contains(executionVertexId),
                 "Trying to allocate a logical slot for execution %s which is not in the ExecutionSlotSharingGroup",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/UpdateSchedulerNgOnInternalFailuresListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/UpdateSchedulerNgOnInternalFailuresListener.java
@@ -31,7 +31,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * Calls {@link SchedulerNG#updateTaskExecutionState(TaskExecutionStateTransition)} on task failure.
  * Calls {@link SchedulerNG#handleGlobalFailure(Throwable)} on global failures.
  */
-class UpdateSchedulerNgOnInternalFailuresListener implements InternalFailuresListener {
+public class UpdateSchedulerNgOnInternalFailuresListener implements InternalFailuresListener {
 
     private final SchedulerNG schedulerNg;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
@@ -509,12 +509,12 @@ public class DeclarativeScheduler implements SchedulerNG {
         return new ParallelismAndResourceAssignments(assignedSlots, parallelismPerJobVertex);
     }
 
-    private static final class ParallelismAndResourceAssignments {
+    static final class ParallelismAndResourceAssignments {
         private final Map<ExecutionVertexID, ? extends LogicalSlot> assignedSlots;
 
         private final Map<JobVertexID, Integer> parallelismPerJobVertex;
 
-        private ParallelismAndResourceAssignments(
+        ParallelismAndResourceAssignments(
                 Map<ExecutionVertexID, ? extends LogicalSlot> assignedSlots,
                 Map<JobVertexID, Integer> parallelismPerJobVertex) {
             this.assignedSlots = assignedSlots;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
@@ -125,7 +125,7 @@ public class DeclarativeScheduler implements SchedulerNG {
             counter += vertex.getParallelism();
         }
 
-        return ResourceCounter.withResource(ResourceProfile.ANY, counter);
+        return ResourceCounter.withResource(ResourceProfile.UNKNOWN, counter);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
@@ -20,17 +20,29 @@ package org.apache.flink.runtime.scheduler.declarative;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.queryablestate.KvStateID;
+import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
+import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionDeploymentListener;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphBuilder;
+import org.apache.flink.runtime.executiongraph.ExecutionStateUpdateListener;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
+import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -38,12 +50,23 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
+import org.apache.flink.runtime.jobmanager.scheduler.Locality;
+import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
+import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTrackerDeploymentListenerAdapter;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SerializedInputSplit;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPool;
+import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.ResourceCounter;
+import org.apache.flink.runtime.jobmaster.slotpool.SingleLogicalSlot;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
+import org.apache.flink.runtime.jobmaster.slotpool.ThrowingSlotProvider;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
@@ -51,6 +74,8 @@ import org.apache.flink.runtime.query.KvStateLocation;
 import org.apache.flink.runtime.query.UnknownKvStateLocation;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
 import org.apache.flink.runtime.scheduler.SchedulerNG;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
@@ -61,8 +86,15 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Declarative {@link SchedulerNG} implementation which first declares the required resources and
@@ -75,6 +107,18 @@ public class DeclarativeScheduler implements SchedulerNG {
     private final Logger logger;
 
     private final DeclarativeSlotPool declarativeSlotPool;
+    private final Configuration configuration;
+    private final ScheduledExecutorService futureExecutor;
+    private final Executor ioExecutor;
+    private final ClassLoader userCodeClassLoader;
+    private final Time rpcTimeout;
+    private final BlobWriter blobWriter;
+    private final ShuffleMaster<?> shuffleMaster;
+    private final JobMasterPartitionTracker partitionTracker;
+    private final ExecutionDeploymentTracker executionDeploymentTracker;
+    private final long initializationTimestamp;
+    private final CheckpointRecoveryFactory checkpointRecoveryFactory;
+    private final JobManagerJobMetricGroup jobManagerJobMetricGroup;
 
     private JobStatus jobStatus = JobStatus.CREATED;
 
@@ -84,11 +128,45 @@ public class DeclarativeScheduler implements SchedulerNG {
             new ComponentMainThreadExecutor.DummyComponentMainThreadExecutor(
                     "DeclarativeScheduler has not been initialized.");
 
+    private SchedulerState state = SchedulerState.CREATED;
+
+    private long schedulingAttempt = 0;
+
+    private ResourceCounter desiredResources = ResourceCounter.empty();
+
+    @Nullable private ExecutionGraph executionGraph = null;
+
     public DeclarativeScheduler(
-            JobGraph jobGraph, Logger logger, DeclarativeSlotPool declarativeSlotPool) {
+            JobGraph jobGraph,
+            Configuration configuration,
+            Logger logger,
+            DeclarativeSlotPool declarativeSlotPool,
+            ScheduledExecutorService futureExecutor,
+            Executor ioExecutor,
+            ClassLoader userCodeClassLoader,
+            CheckpointRecoveryFactory checkpointRecoveryFactory,
+            Time rpcTimeout,
+            BlobWriter blobWriter,
+            JobManagerJobMetricGroup jobManagerJobMetricGroup,
+            ShuffleMaster<?> shuffleMaster,
+            JobMasterPartitionTracker partitionTracker,
+            ExecutionDeploymentTracker executionDeploymentTracker,
+            long initializationTimestamp) {
         this.jobGraph = jobGraph;
+        this.configuration = configuration;
         this.logger = logger;
         this.declarativeSlotPool = declarativeSlotPool;
+        this.futureExecutor = futureExecutor;
+        this.ioExecutor = ioExecutor;
+        this.userCodeClassLoader = userCodeClassLoader;
+        this.checkpointRecoveryFactory = checkpointRecoveryFactory;
+        this.rpcTimeout = rpcTimeout;
+        this.blobWriter = blobWriter;
+        this.jobManagerJobMetricGroup = jobManagerJobMetricGroup;
+        this.shuffleMaster = shuffleMaster;
+        this.partitionTracker = partitionTracker;
+        this.executionDeploymentTracker = executionDeploymentTracker;
+        this.initializationTimestamp = initializationTimestamp;
     }
 
     @Override
@@ -108,17 +186,218 @@ public class DeclarativeScheduler implements SchedulerNG {
     @Override
     public void startScheduling() {
         declareResources();
-        scheduleJobGraph();
+
+        try {
+            waitForResources();
+        } catch (Exception e) {
+            handleFatalFailure(new FlinkException("Failed to wait for resources.", e));
+        }
     }
 
-    private void scheduleJobGraph() {}
+    private void waitForResources() throws Exception {
+        state = SchedulerState.WAITING_FOR_RESOURCES;
+        schedulingAttempt++;
+
+        if (!scheduleIfEnoughResources()) {
+            mainThreadExecutor.schedule(
+                    () -> resourceTimeout(schedulingAttempt), 10L, TimeUnit.SECONDS);
+        }
+    }
+
+    private boolean scheduleIfEnoughResources() throws Exception {
+        if (hasEnoughResources()) {
+            scheduleExecutionGraphWithExistingResources();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private boolean hasEnoughResources() {
+        final Collection<? extends SlotInfo> allSlots =
+                declarativeSlotPool.getFreeSlotsInformation();
+        ResourceCounter outstandingResources = desiredResources;
+
+        final Iterator<? extends SlotInfo> slotIterator = allSlots.iterator();
+
+        while (!outstandingResources.isEmpty() && slotIterator.hasNext()) {
+            outstandingResources =
+                    outstandingResources.subtract(slotIterator.next().getResourceProfile(), 1);
+        }
+
+        return outstandingResources.isEmpty();
+    }
+
+    private void resourceTimeout(long timeoutForSchedulingAttempt) {
+        if (timeoutForSchedulingAttempt == schedulingAttempt) {
+            try {
+                scheduleExecutionGraphWithExistingResources();
+            } catch (Exception e) {
+                handleFatalFailure(
+                        new FlinkException("Failed to schedule the execution graph.", e));
+            }
+        }
+    }
+
+    private void scheduleExecutionGraphWithExistingResources() throws Exception {
+        logger.info("Start scheduling job with existing resources.");
+        Preconditions.checkState(
+                state == SchedulerState.WAITING_FOR_RESOURCES,
+                "Can only schedule the ExecutionGraph after having waited for resources.");
+        state = SchedulerState.EXECUTING;
+
+        createExecutionGraphAndAssignResources();
+        deployExecutionGraph();
+    }
+
+    private void createExecutionGraphAndAssignResources() throws Exception {
+        logger.debug("Calculate parallelism of job and assign resources.");
+
+        final ParallelismAndResourceAssignments parallelismAndResourceAssignments =
+                determineParallelismAndAssignResources(jobGraph);
+
+        for (JobVertex vertex : jobGraph.getVertices()) {
+            vertex.setParallelism(parallelismAndResourceAssignments.getParallelism(vertex.getID()));
+        }
+
+        ExecutionDeploymentListener executionDeploymentListener =
+                new ExecutionDeploymentTrackerDeploymentListenerAdapter(executionDeploymentTracker);
+        ExecutionStateUpdateListener executionStateUpdateListener =
+                (execution, newState) -> {
+                    if (newState.isTerminal()) {
+                        executionDeploymentTracker.stopTrackingDeploymentOf(execution);
+                    }
+                };
+
+        executionGraph =
+                ExecutionGraphBuilder.buildGraph(
+                        null,
+                        jobGraph,
+                        configuration,
+                        futureExecutor,
+                        ioExecutor,
+                        new ThrowingSlotProvider(),
+                        userCodeClassLoader,
+                        checkpointRecoveryFactory,
+                        rpcTimeout,
+                        jobManagerJobMetricGroup,
+                        blobWriter,
+                        Time.milliseconds(0L),
+                        logger,
+                        shuffleMaster,
+                        partitionTracker,
+                        executionDeploymentListener,
+                        executionStateUpdateListener,
+                        initializationTimestamp);
+        executionGraph.start(mainThreadExecutor);
+        //		executionGraph.setInternalTaskFailuresListener(null);
+
+        for (ExecutionVertex executionVertex : executionGraph.getAllExecutionVertices()) {
+            final LogicalSlot assignedSlot =
+                    parallelismAndResourceAssignments.getAssignedSlot(executionVertex.getID());
+            executionVertex.tryAssignResource(assignedSlot);
+        }
+    }
+
+    public void handleFatalFailure(Throwable failure) {
+        Preconditions.checkState(jobStatusListener != null, "JobStatusListener has not been set.");
+        jobStatusListener.jobStatusChanges(
+                jobGraph.getJobID(), JobStatus.FAILED, System.currentTimeMillis(), failure);
+    }
+
+    private ParallelismAndResourceAssignments determineParallelismAndAssignResources(
+            JobGraph jobGraph) {
+        final HashMap<ExecutionVertexID, LogicalSlot> assignedSlots = new HashMap<>();
+        final HashMap<JobVertexID, Integer> parallelismPerJobVertex = new HashMap<>();
+
+        final Collection<SlotInfoWithUtilization> freeSlots =
+                declarativeSlotPool.getFreeSlotsInformation();
+        final int slotsPerVertex = freeSlots.size() / jobGraph.getNumberOfVertices();
+        final Iterator<SlotInfoWithUtilization> slotIterator = freeSlots.iterator();
+
+        for (JobVertex jobVertex : jobGraph.getVerticesSortedTopologicallyFromSources()) {
+            final int parallelism = Math.min(jobVertex.getParallelism(), slotsPerVertex);
+            jobVertex.setParallelism(parallelism);
+
+            parallelismPerJobVertex.put(jobVertex.getID(), parallelism);
+
+            for (int i = 0; i < slotsPerVertex; i++) {
+                final SlotInfoWithUtilization slotInfo = slotIterator.next();
+
+                final PhysicalSlot physicalSlot =
+                        declarativeSlotPool.reserveFreeSlot(
+                                slotInfo.getAllocationId(),
+                                ResourceProfile.fromResourceSpec(
+                                        jobVertex.getMinResources(), MemorySize.ZERO));
+
+                assignedSlots.put(
+                        new ExecutionVertexID(jobVertex.getID(), i),
+                        new SingleLogicalSlot(
+                                new SlotRequestId(),
+                                physicalSlot,
+                                null,
+                                Locality.UNKNOWN,
+                                logicalSlot ->
+                                        declarativeSlotPool.freeReservedSlot(
+                                                physicalSlot.getAllocationId(),
+                                                null,
+                                                System.currentTimeMillis())));
+            }
+        }
+
+        return new ParallelismAndResourceAssignments(assignedSlots, parallelismPerJobVertex);
+    }
+
+    private static final class ParallelismAndResourceAssignments {
+        private final Map<ExecutionVertexID, ? extends LogicalSlot> assignedSlots;
+
+        private final Map<JobVertexID, Integer> parallelismPerJobVertex;
+
+        private ParallelismAndResourceAssignments(
+                Map<ExecutionVertexID, ? extends LogicalSlot> assignedSlots,
+                Map<JobVertexID, Integer> parallelismPerJobVertex) {
+            this.assignedSlots = assignedSlots;
+            this.parallelismPerJobVertex = parallelismPerJobVertex;
+        }
+
+        public int getParallelism(JobVertexID jobVertexId) {
+            Preconditions.checkState(parallelismPerJobVertex.containsKey(jobVertexId));
+            return parallelismPerJobVertex.get(jobVertexId);
+        }
+
+        public LogicalSlot getAssignedSlot(ExecutionVertexID executionVertexId) {
+            Preconditions.checkState(assignedSlots.containsKey(executionVertexId));
+            return assignedSlots.get(executionVertexId);
+        }
+    }
+
+    private void deployExecutionGraph() {
+        Preconditions.checkNotNull(
+                executionGraph, "The ExecutionGraph must not be null when being deployed.");
+
+        for (ExecutionVertex executionVertex : executionGraph.getAllExecutionVertices()) {
+            deploySafely(executionVertex);
+        }
+    }
+
+    private void deploySafely(ExecutionVertex executionVertex) {
+        try {
+            executionVertex.deploy();
+        } catch (JobException e) {
+            handleDeploymentFailure(executionVertex, e);
+        }
+    }
+
+    private void handleDeploymentFailure(ExecutionVertex executionVertex, JobException e) {
+        executionVertex.markFailed(e);
+    }
 
     private void declareResources() {
-        final ResourceCounter requiredResources = calculateRequiredResources();
-        declarativeSlotPool.increaseResourceRequirementsBy(requiredResources);
+        desiredResources = calculateDesiredResources();
+        declarativeSlotPool.increaseResourceRequirementsBy(desiredResources);
     }
 
-    private ResourceCounter calculateRequiredResources() {
+    private ResourceCounter calculateDesiredResources() {
         int counter = 0;
 
         for (JobVertex vertex : jobGraph.getVertices()) {
@@ -150,7 +429,11 @@ public class DeclarativeScheduler implements SchedulerNG {
 
     @Override
     public boolean updateTaskExecutionState(TaskExecutionStateTransition taskExecutionState) {
-        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+        if (state == SchedulerState.EXECUTING && executionGraph != null) {
+            return executionGraph.updateState(taskExecutionState);
+        } else {
+            return false;
+        }
     }
 
     @Override
@@ -216,7 +499,9 @@ public class DeclarativeScheduler implements SchedulerNG {
 
     @Override
     public void updateAccumulators(AccumulatorSnapshot accumulatorSnapshot) {
-        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+        if (state == SchedulerState.EXECUTING && executionGraph != null) {
+            executionGraph.updateAccumulators(accumulatorSnapshot);
+        }
     }
 
     @Override
@@ -263,5 +548,11 @@ public class DeclarativeScheduler implements SchedulerNG {
     public CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
             OperatorID operator, CoordinationRequest request) throws FlinkException {
         throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    private enum SchedulerState {
+        CREATED,
+        WAITING_FOR_RESOURCES,
+        EXECUTING,
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.queryablestate.KvStateID;
+import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
+import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.JobStatusListener;
+import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
+import org.apache.flink.runtime.jobmaster.SerializedInputSplit;
+import org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPool;
+import org.apache.flink.runtime.jobmaster.slotpool.ResourceCounter;
+import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.runtime.query.KvStateLocation;
+import org.apache.flink.runtime.query.UnknownKvStateLocation;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
+import org.apache.flink.runtime.scheduler.SchedulerNG;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Declarative {@link SchedulerNG} implementation which first declares the required resources and
+ * then decides on the parallelism with which to execute the given {@link JobGraph}.
+ */
+public class DeclarativeScheduler implements SchedulerNG {
+
+    private final JobGraph jobGraph;
+
+    private final Logger logger;
+
+    private final DeclarativeSlotPool declarativeSlotPool;
+
+    private JobStatus jobStatus = JobStatus.CREATED;
+
+    @Nullable private JobStatusListener jobStatusListener;
+
+    private ComponentMainThreadExecutor mainThreadExecutor =
+            new ComponentMainThreadExecutor.DummyComponentMainThreadExecutor(
+                    "DeclarativeScheduler has not been initialized.");
+
+    public DeclarativeScheduler(
+            JobGraph jobGraph, Logger logger, DeclarativeSlotPool declarativeSlotPool) {
+        this.jobGraph = jobGraph;
+        this.logger = logger;
+        this.declarativeSlotPool = declarativeSlotPool;
+    }
+
+    @Override
+    public void initialize(ComponentMainThreadExecutor mainThreadExecutor) {
+        this.mainThreadExecutor = mainThreadExecutor;
+    }
+
+    @Override
+    public void registerJobStatusListener(JobStatusListener jobStatusListener) {
+        Preconditions.checkState(
+                this.jobStatusListener == null,
+                "DeclarativeScheduler does not support multiple JobStatusListeners.");
+
+        this.jobStatusListener = jobStatusListener;
+    }
+
+    @Override
+    public void startScheduling() {
+        declareResources();
+        scheduleJobGraph();
+    }
+
+    private void scheduleJobGraph() {}
+
+    private void declareResources() {
+        final ResourceCounter requiredResources = calculateRequiredResources();
+        declarativeSlotPool.increaseResourceRequirementsBy(requiredResources);
+    }
+
+    private ResourceCounter calculateRequiredResources() {
+        int counter = 0;
+
+        for (JobVertex vertex : jobGraph.getVertices()) {
+            counter += vertex.getParallelism();
+        }
+
+        return ResourceCounter.withResource(ResourceProfile.ANY, counter);
+    }
+
+    @Override
+    public void suspend(Throwable cause) {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public void cancel() {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public CompletableFuture<Void> getTerminationFuture() {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public void handleGlobalFailure(Throwable cause) {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public boolean updateTaskExecutionState(TaskExecutionStateTransition taskExecutionState) {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public SerializedInputSplit requestNextInputSplit(
+            JobVertexID vertexID, ExecutionAttemptID executionAttempt) throws IOException {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public ExecutionState requestPartitionState(
+            IntermediateDataSetID intermediateResultId, ResultPartitionID resultPartitionId)
+            throws PartitionProducerDisposedException {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public void notifyPartitionDataAvailable(ResultPartitionID partitionID) {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public ArchivedExecutionGraph requestJob() {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public JobStatus requestJobStatus() {
+        return jobStatus;
+    }
+
+    @Override
+    public JobDetails requestJobDetails() {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public KvStateLocation requestKvStateLocation(JobID jobId, String registrationName)
+            throws UnknownKvStateLocation, FlinkJobNotFoundException {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public void notifyKvStateRegistered(
+            JobID jobId,
+            JobVertexID jobVertexId,
+            KeyGroupRange keyGroupRange,
+            String registrationName,
+            KvStateID kvStateId,
+            InetSocketAddress kvStateServerAddress)
+            throws FlinkJobNotFoundException {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public void notifyKvStateUnregistered(
+            JobID jobId,
+            JobVertexID jobVertexId,
+            KeyGroupRange keyGroupRange,
+            String registrationName)
+            throws FlinkJobNotFoundException {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public void updateAccumulators(AccumulatorSnapshot accumulatorSnapshot) {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public Optional<OperatorBackPressureStats> requestOperatorBackPressureStats(
+            JobVertexID jobVertexId) throws FlinkException {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public CompletableFuture<String> triggerSavepoint(
+            @Nullable String targetDirectory, boolean cancelJob) {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public void acknowledgeCheckpoint(
+            JobID jobID,
+            ExecutionAttemptID executionAttemptID,
+            long checkpointId,
+            CheckpointMetrics checkpointMetrics,
+            TaskStateSnapshot checkpointState) {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public void declineCheckpoint(DeclineCheckpoint decline) {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public CompletableFuture<String> stopWithSavepoint(
+            String targetDirectory, boolean advanceToEndOfEventTime) {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public void deliverOperatorEventToCoordinator(
+            ExecutionAttemptID taskExecution, OperatorID operator, OperatorEvent evt)
+            throws FlinkException {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+
+    @Override
+    public CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
+            OperatorID operator, CoordinationRequest request) throws FlinkException {
+        throw new UnsupportedOperationException("Not supported by the declarative scheduler.");
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.scheduler.declarative;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
@@ -48,6 +49,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionStateUpdateListener;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
@@ -57,7 +59,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
-import org.apache.flink.runtime.jobmanager.scheduler.Locality;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTrackerDeploymentListenerAdapter;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
@@ -67,7 +69,6 @@ import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPool;
 import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.ResourceCounter;
-import org.apache.flink.runtime.jobmaster.slotpool.SingleLogicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
 import org.apache.flink.runtime.jobmaster.slotpool.ThrowingSlotProvider;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
@@ -81,8 +82,10 @@ import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.query.KvStateLocation;
 import org.apache.flink.runtime.query.UnknownKvStateLocation;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
+import org.apache.flink.runtime.scheduler.ExecutionSlotSharingGroup;
 import org.apache.flink.runtime.scheduler.SchedulerNG;
 import org.apache.flink.runtime.scheduler.SchedulerUtils;
+import org.apache.flink.runtime.scheduler.SharedSlot;
 import org.apache.flink.runtime.scheduler.UpdateSchedulerNgOnInternalFailuresListener;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
@@ -103,12 +106,16 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
  * Declarative {@link SchedulerNG} implementation which first declares the required resources and
@@ -471,45 +478,93 @@ public class DeclarativeScheduler implements SchedulerNG {
 
         final Collection<SlotInfoWithUtilization> freeSlots =
                 declarativeSlotPool.getFreeSlotsInformation();
-        final int slotsPerVertex = freeSlots.size() / jobGraph.getNumberOfVertices();
+        // TODO: This can waste slots if the max parallelism for slot sharing groups is not equal
+        final int slotsPerSlotSharingGroup =
+                freeSlots.size() / jobGraph.getSlotSharingGroups().size();
         final Iterator<SlotInfoWithUtilization> slotIterator = freeSlots.iterator();
 
-        for (JobVertex jobVertex : jobGraph.getVerticesSortedTopologicallyFromSources()) {
-            final int parallelism = Math.min(jobVertex.getParallelism(), slotsPerVertex);
-            jobVertex.setParallelism(parallelism);
+        for (SlotSharingGroup slotSharingGroup : jobGraph.getSlotSharingGroups()) {
+            final List<JobVertex> containedJobVertices =
+                    slotSharingGroup.getJobVertexIds().stream()
+                            .map(jobGraph::findVertexByID)
+                            .collect(Collectors.toList());
 
-            parallelismPerJobVertex.put(jobVertex.getID(), parallelism);
+            final Map<Integer, Set<ExecutionVertexID>> sharedSlotToVertexAssignment =
+                    determineParallelismAndAssignToFutureSlotIndex(
+                            containedJobVertices,
+                            slotsPerSlotSharingGroup,
+                            parallelismPerJobVertex);
 
-            for (int i = 0; i < slotsPerVertex; i++) {
+            for (int i = 0; i < slotsPerSlotSharingGroup; i++) {
                 final SlotInfoWithUtilization slotInfo = slotIterator.next();
 
-                final PhysicalSlot physicalSlot =
-                        declarativeSlotPool.reserveFreeSlot(
-                                slotInfo.getAllocationId(),
-                                ResourceProfile.fromResourceSpec(
-                                        jobVertex.getMinResources(), MemorySize.ZERO));
+                final Set<ExecutionVertexID> containedExecutionVertices =
+                        sharedSlotToVertexAssignment.get(i);
 
-                final SingleLogicalSlot logicalSlot =
-                        new SingleLogicalSlot(
-                                new SlotRequestId(),
-                                physicalSlot,
-                                null,
-                                Locality.UNKNOWN,
-                                slot ->
-                                        declarativeSlotPool.freeReservedSlot(
-                                                physicalSlot.getAllocationId(),
-                                                null,
-                                                System.currentTimeMillis()));
-                physicalSlot.tryAssignPayload(logicalSlot);
+                final SharedSlot sharedSlot =
+                        reserveSharedSlot(slotInfo, containedExecutionVertices);
 
-                assignedSlots.put(new ExecutionVertexID(jobVertex.getID(), i), logicalSlot);
+                for (ExecutionVertexID executionVertexId : containedExecutionVertices) {
+                    final LogicalSlot logicalSlot;
+                    try {
+                        logicalSlot = sharedSlot.allocateLogicalSlot(executionVertexId).get();
+                    } catch (InterruptedException | ExecutionException e) {
+                        throw new RuntimeException("Should not have failed.");
+                    }
+                    assignedSlots.put(executionVertexId, logicalSlot);
+                }
             }
         }
 
         return new ParallelismAndResourceAssignments(assignedSlots, parallelismPerJobVertex);
     }
 
-    static final class ParallelismAndResourceAssignments {
+    private Map<Integer, Set<ExecutionVertexID>> determineParallelismAndAssignToFutureSlotIndex(
+            Collection<JobVertex> containedJobVertices,
+            int availableSlots,
+            // TODO: get rid of this parameter
+            Map<JobVertexID, Integer> parallelismPerJobVertex) {
+        final Map<Integer, Set<ExecutionVertexID>> sharedSlotToVertexAssignment = new HashMap<>();
+        for (JobVertex jobVertex : containedJobVertices) {
+            final int parallelism = Math.min(jobVertex.getParallelism(), availableSlots);
+            jobVertex.setParallelism(parallelism);
+
+            parallelismPerJobVertex.put(jobVertex.getID(), parallelism);
+            for (int i = 0; i < parallelism; i++) {
+                sharedSlotToVertexAssignment
+                        .computeIfAbsent(i, ignored -> new HashSet<>())
+                        .add(new ExecutionVertexID(jobVertex.getID(), i));
+            }
+        }
+        return sharedSlotToVertexAssignment;
+    }
+
+    private SharedSlot reserveSharedSlot(
+            SlotInfo slotInfo, Set<ExecutionVertexID> containedExecutionVertices) {
+        final PhysicalSlot physicalSlot =
+                declarativeSlotPool.reserveFreeSlot(
+                        slotInfo.getAllocationId(),
+                        ResourceProfile.fromResourceSpec(ResourceSpec.DEFAULT, MemorySize.ZERO));
+
+        final SharedSlot sharedSlot =
+                new SharedSlot(
+                        new SlotRequestId(),
+                        slotInfo.getResourceProfile(),
+                        ExecutionSlotSharingGroup.forVertexIds(containedExecutionVertices),
+                        CompletableFuture.completedFuture(physicalSlot),
+                        slotInfo.willBeOccupiedIndefinitely(),
+                        ignored ->
+                                declarativeSlotPool.freeReservedSlot(
+                                        slotInfo.getAllocationId(),
+                                        null,
+                                        System.currentTimeMillis()));
+        physicalSlot.tryAssignPayload(sharedSlot);
+
+        return sharedSlot;
+    }
+
+    /** Assignment of slots to execution vertices. */
+    public static final class ParallelismAndResourceAssignments {
         private final Map<ExecutionVertexID, ? extends LogicalSlot> assignedSlots;
 
         private final Map<JobVertexID, Integer> parallelismPerJobVertex;
@@ -559,13 +614,25 @@ public class DeclarativeScheduler implements SchedulerNG {
     }
 
     private ResourceCounter calculateDesiredResources() {
-        int counter = 0;
-
-        for (JobVertex vertex : jobGraph.getVertices()) {
-            counter += vertex.getParallelism();
+        int numTotalRequiredSlots = 0;
+        for (Integer requiredSlots : getMaxParallelismForSlotSharingGroups(jobGraph).values()) {
+            numTotalRequiredSlots += requiredSlots;
         }
+        return ResourceCounter.withResource(ResourceProfile.UNKNOWN, numTotalRequiredSlots);
+    }
 
-        return ResourceCounter.withResource(ResourceProfile.UNKNOWN, counter);
+    private static Map<SlotSharingGroupId, Integer> getMaxParallelismForSlotSharingGroups(
+            JobGraph jobGraph) {
+        final Map<SlotSharingGroupId, Integer> maxParallelismForSlotSharingGroups = new HashMap<>();
+        for (JobVertex vertex : jobGraph.getVertices()) {
+            maxParallelismForSlotSharingGroups.compute(
+                    vertex.getSlotSharingGroup().getSlotSharingGroupId(),
+                    (slotSharingGroupId, currentMaxParallelism) ->
+                            currentMaxParallelism == null
+                                    ? vertex.getParallelism()
+                                    : Math.max(currentMaxParallelism, vertex.getParallelism()));
+        }
+        return maxParallelismForSlotSharingGroups;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
@@ -75,6 +75,7 @@ import org.apache.flink.runtime.query.KvStateLocation;
 import org.apache.flink.runtime.query.UnknownKvStateLocation;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
 import org.apache.flink.runtime.scheduler.SchedulerNG;
+import org.apache.flink.runtime.scheduler.UpdateSchedulerNgOnInternalFailuresListener;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -327,7 +328,9 @@ public class DeclarativeScheduler implements SchedulerNG {
                                         handleTerminalState(terminalState);
                                     }
                                 }));
-        //		executionGraph.setInternalTaskFailuresListener(null);
+
+        executionGraph.setInternalTaskFailuresListener(
+                new UpdateSchedulerNgOnInternalFailuresListener(this, jobGraph.getJobID()));
 
         for (ExecutionVertex executionVertex : executionGraph.getAllExecutionVertices()) {
             final LogicalSlot assignedSlot =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerFactory.java
@@ -68,7 +68,7 @@ public class DeclarativeSchedulerFactory implements SchedulerNGFactory {
                                         new IllegalStateException(
                                                 "The DeclarativeScheduler requires a DeclarativeSlotPool."));
 
-        return new DeclarativeScheduler(
+        return new DeclarativeSchedulerNG(
                 jobGraph,
                 jobMasterConfiguration,
                 log,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerFactory.java
@@ -68,6 +68,21 @@ public class DeclarativeSchedulerFactory implements SchedulerNGFactory {
                                         new IllegalStateException(
                                                 "The DeclarativeScheduler requires a DeclarativeSlotPool."));
 
-        return new DeclarativeScheduler(jobGraph, log, declarativeSlotPool);
+        return new DeclarativeScheduler(
+                jobGraph,
+                jobMasterConfiguration,
+                log,
+                declarativeSlotPool,
+                futureExecutor,
+                ioExecutor,
+                userCodeLoader,
+                checkpointRecoveryFactory,
+                rpcTimeout,
+                blobWriter,
+                jobManagerJobMetricGroup,
+                shuffleMaster,
+                partitionTracker,
+                executionDeploymentTracker,
+                initializationTimestamp);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.scheduler.declarative;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
@@ -67,23 +68,44 @@ public class DeclarativeSchedulerFactory implements SchedulerNGFactory {
                                 () ->
                                         new IllegalStateException(
                                                 "The DeclarativeScheduler requires a DeclarativeSlotPool."));
-
-        return new DeclarativeSchedulerNG(
-                jobGraph,
-                jobMasterConfiguration,
-                log,
-                declarativeSlotPool,
-                futureExecutor,
-                ioExecutor,
-                userCodeLoader,
-                checkpointRecoveryFactory,
-                rpcTimeout,
-                blobWriter,
-                jobManagerJobMetricGroup,
-                shuffleMaster,
-                partitionTracker,
-                executionDeploymentTracker,
-                backPressureStatsTracker,
-                initializationTimestamp);
+        switch (jobMasterConfiguration.get(JobManagerOptions.DECLARATIVE_SCHEDULER_TYPE)) {
+            case StateMachine:
+                return new DeclarativeSchedulerNG(
+                        jobGraph,
+                        jobMasterConfiguration,
+                        log,
+                        declarativeSlotPool,
+                        futureExecutor,
+                        ioExecutor,
+                        userCodeLoader,
+                        checkpointRecoveryFactory,
+                        rpcTimeout,
+                        blobWriter,
+                        jobManagerJobMetricGroup,
+                        shuffleMaster,
+                        partitionTracker,
+                        executionDeploymentTracker,
+                        backPressureStatsTracker,
+                        initializationTimestamp);
+            case Old:
+                return new DeclarativeScheduler(
+                        jobGraph,
+                        jobMasterConfiguration,
+                        log,
+                        declarativeSlotPool,
+                        futureExecutor,
+                        ioExecutor,
+                        userCodeLoader,
+                        checkpointRecoveryFactory,
+                        rpcTimeout,
+                        blobWriter,
+                        jobManagerJobMetricGroup,
+                        shuffleMaster,
+                        partitionTracker,
+                        executionDeploymentTracker,
+                        initializationTimestamp);
+            default:
+                throw new IllegalStateException("Unknown scheduler type");
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerFactory.java
@@ -83,6 +83,7 @@ public class DeclarativeSchedulerFactory implements SchedulerNGFactory {
                 shuffleMaster,
                 partitionTracker,
                 executionDeploymentTracker,
+                backPressureStatsTracker,
                 initializationTimestamp);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobWriter;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
+import org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPool;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolService;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
+import org.apache.flink.runtime.scheduler.SchedulerNG;
+import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
+
+import org.slf4j.Logger;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+
+/** Factory for the {@link DeclarativeScheduler}. */
+public class DeclarativeSchedulerFactory implements SchedulerNGFactory {
+    @Override
+    public SchedulerNG createInstance(
+            Logger log,
+            JobGraph jobGraph,
+            BackPressureStatsTracker backPressureStatsTracker,
+            Executor ioExecutor,
+            Configuration jobMasterConfiguration,
+            SlotPoolService slotPoolService,
+            ScheduledExecutorService futureExecutor,
+            ClassLoader userCodeLoader,
+            CheckpointRecoveryFactory checkpointRecoveryFactory,
+            Time rpcTimeout,
+            BlobWriter blobWriter,
+            JobManagerJobMetricGroup jobManagerJobMetricGroup,
+            Time slotRequestTimeout,
+            ShuffleMaster<?> shuffleMaster,
+            JobMasterPartitionTracker partitionTracker,
+            ExecutionDeploymentTracker executionDeploymentTracker,
+            long initializationTimestamp)
+            throws Exception {
+        final DeclarativeSlotPool declarativeSlotPool =
+                slotPoolService
+                        .castInto(DeclarativeSlotPool.class)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "The DeclarativeScheduler requires a DeclarativeSlotPool."));
+
+        return new DeclarativeScheduler(jobGraph, log, declarativeSlotPool);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerNG.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.scheduler.declarative;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.core.io.InputSplit;
@@ -29,15 +30,19 @@ import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.Execution;
@@ -79,10 +84,16 @@ import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequestHandler;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinatorHolder;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.runtime.operators.coordination.TaskNotRunningException;
 import org.apache.flink.runtime.query.KvStateLocation;
+import org.apache.flink.runtime.query.KvStateLocationRegistry;
 import org.apache.flink.runtime.query.UnknownKvStateLocation;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
 import org.apache.flink.runtime.scheduler.SchedulerNG;
 import org.apache.flink.runtime.scheduler.SchedulerUtils;
@@ -94,9 +105,9 @@ import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.InstantiationUtil;
-import org.apache.flink.util.OptionalConsumer;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.FunctionWithException;
+import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,12 +121,14 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
+import java.util.function.Function;
 
 /** Declarative scheduler ng. */
 public class DeclarativeSchedulerNG implements SchedulerNG {
@@ -138,6 +151,7 @@ public class DeclarativeSchedulerNG implements SchedulerNG {
     private final JobMasterPartitionTracker partitionTracker;
     private final ExecutionDeploymentTracker executionDeploymentTracker;
     private final JobManagerJobMetricGroup jobManagerJobMetricGroup;
+    private final BackPressureStatsTracker backPressureStatsTracker;
 
     private final CompletedCheckpointStore completedCheckpointStore;
     private final CheckpointIDCounter checkpointIdCounter;
@@ -167,6 +181,7 @@ public class DeclarativeSchedulerNG implements SchedulerNG {
             ShuffleMaster<?> shuffleMaster,
             JobMasterPartitionTracker partitionTracker,
             ExecutionDeploymentTracker executionDeploymentTracker,
+            BackPressureStatsTracker backPressureStatsTracker,
             long initializationTimestamp)
             throws JobExecutionException {
 
@@ -183,6 +198,7 @@ public class DeclarativeSchedulerNG implements SchedulerNG {
         this.partitionTracker = partitionTracker;
         this.executionDeploymentTracker = executionDeploymentTracker;
         this.jobManagerJobMetricGroup = jobManagerJobMetricGroup;
+        this.backPressureStatsTracker = backPressureStatsTracker;
         this.completedCheckpointStore =
                 SchedulerUtils.createCompletedCheckpointStoreIfCheckpointingIsEnabled(
                         jobGraph,
@@ -447,7 +463,14 @@ public class DeclarativeSchedulerNG implements SchedulerNG {
     @Override
     public KvStateLocation requestKvStateLocation(JobID jobId, String registrationName)
             throws UnknownKvStateLocation, FlinkJobNotFoundException {
-        return null;
+        final Optional<StateWithExecutionGraph> asOptional =
+                state.as(StateWithExecutionGraph.class);
+
+        if (asOptional.isPresent()) {
+            return asOptional.get().requestKvStateLocation(jobId, registrationName);
+        } else {
+            throw new UnknownKvStateLocation(registrationName);
+        }
     }
 
     @Override
@@ -458,7 +481,19 @@ public class DeclarativeSchedulerNG implements SchedulerNG {
             String registrationName,
             KvStateID kvStateId,
             InetSocketAddress kvStateServerAddress)
-            throws FlinkJobNotFoundException {}
+            throws FlinkJobNotFoundException {
+        state.tryRun(
+                StateWithExecutionGraph.class,
+                stateWithExecutionGraph ->
+                        stateWithExecutionGraph.notifyKvStateRegistered(
+                                jobId,
+                                jobVertexId,
+                                keyGroupRange,
+                                registrationName,
+                                kvStateId,
+                                kvStateServerAddress),
+                "notifyKvStateRegistered");
+    }
 
     @Override
     public void notifyKvStateUnregistered(
@@ -466,7 +501,14 @@ public class DeclarativeSchedulerNG implements SchedulerNG {
             JobVertexID jobVertexId,
             KeyGroupRange keyGroupRange,
             String registrationName)
-            throws FlinkJobNotFoundException {}
+            throws FlinkJobNotFoundException {
+        state.tryRun(
+                StateWithExecutionGraph.class,
+                stateWithExecutionGraph ->
+                        stateWithExecutionGraph.notifyKvStateUnregistered(
+                                jobId, jobVertexId, keyGroupRange, registrationName),
+                "notifyKvStateUnregistered");
+    }
 
     @Override
     public void updateAccumulators(AccumulatorSnapshot accumulatorSnapshot) {
@@ -480,13 +522,29 @@ public class DeclarativeSchedulerNG implements SchedulerNG {
     @Override
     public Optional<OperatorBackPressureStats> requestOperatorBackPressureStats(
             JobVertexID jobVertexId) throws FlinkException {
-        return Optional.empty();
+        return state.tryCall(
+                        StateWithExecutionGraph.class,
+                        stateWithExecutionGraph ->
+                                stateWithExecutionGraph.requestOperatorBackPressureStats(
+                                        jobVertexId),
+                        "requestOperatorBackPressureStats")
+                .flatMap(Function.identity());
     }
 
     @Override
     public CompletableFuture<String> triggerSavepoint(
             @Nullable String targetDirectory, boolean cancelJob) {
-        return null;
+        return state.tryCall(
+                        StateWithExecutionGraph.class,
+                        stateWithExecutionGraph ->
+                                stateWithExecutionGraph.triggerSavepoint(
+                                        targetDirectory, cancelJob),
+                        "triggerSavepoint")
+                .orElse(
+                        FutureUtils.completedExceptionally(
+                                new CheckpointException(
+                                        "The Flink job is currently not executing.",
+                                        CheckpointFailureReason.TRIGGER_CHECKPOINT_FAILURE)));
     }
 
     @Override
@@ -519,18 +577,51 @@ public class DeclarativeSchedulerNG implements SchedulerNG {
     @Override
     public CompletableFuture<String> stopWithSavepoint(
             String targetDirectory, boolean advanceToEndOfEventTime) {
-        return null;
+        return state.tryCall(
+                        StateWithExecutionGraph.class,
+                        stateWithExecutionGraph ->
+                                stateWithExecutionGraph.stopWithSavepoint(
+                                        targetDirectory, advanceToEndOfEventTime),
+                        "stopWithSavepoint")
+                .orElse(
+                        FutureUtils.completedExceptionally(
+                                new CheckpointException(
+                                        "The Flink job is currently not executing.",
+                                        CheckpointFailureReason.TRIGGER_CHECKPOINT_FAILURE)));
     }
 
     @Override
     public void deliverOperatorEventToCoordinator(
             ExecutionAttemptID taskExecution, OperatorID operator, OperatorEvent evt)
-            throws FlinkException {}
+            throws FlinkException {
+        state.tryCall(
+                        StateWithExecutionGraph.class,
+                        stateWithExecutionGraph ->
+                                stateWithExecutionGraph.deliverOperatorEventToCoordinator(
+                                        taskExecution, operator, evt),
+                        "deliverOperatorEventToCoordinator")
+                .orElseThrow(
+                        () ->
+                                new TaskNotRunningException(
+                                        "Task is not known or in state running on the JobManager."));
+    }
 
     @Override
     public CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
             OperatorID operator, CoordinationRequest request) throws FlinkException {
-        return null;
+        return state.tryCall(
+                        StateWithExecutionGraph.class,
+                        stateWithExecutionGraph ->
+                                stateWithExecutionGraph.deliverCoordinationRequestToCoordinator(
+                                        operator, request),
+                        "deliverCoordinationRequestToCoordinator")
+                .orElseGet(
+                        () ->
+                                FutureUtils.completedExceptionally(
+                                        new FlinkException(
+                                                "Coordinator of operator "
+                                                        + operator
+                                                        + " does not exist")));
     }
 
     // ----------------------------------------------------------------
@@ -961,8 +1052,12 @@ public class DeclarativeSchedulerNG implements SchedulerNG {
     private abstract class StateWithExecutionGraph implements State {
         protected final ExecutionGraph executionGraph;
 
+        private final Map<OperatorID, OperatorCoordinatorHolder> coordinatorMap;
+
         protected StateWithExecutionGraph(ExecutionGraph executionGraph) {
             this.executionGraph = executionGraph;
+
+            this.coordinatorMap = createCoordinatorMap(executionGraph);
 
             executionGraph
                     .getTerminationFuture()
@@ -973,6 +1068,17 @@ public class DeclarativeSchedulerNG implements SchedulerNG {
                                 }
                             },
                             componentMainThreadExecutor);
+        }
+
+        private Map<OperatorID, OperatorCoordinatorHolder> createCoordinatorMap(
+                ExecutionGraph executionGraph) {
+            Map<OperatorID, OperatorCoordinatorHolder> coordinatorMap = new HashMap<>();
+            for (ExecutionJobVertex vertex : executionGraph.getAllVertices().values()) {
+                for (OperatorCoordinatorHolder holder : vertex.getOperatorCoordinators()) {
+                    coordinatorMap.put(holder.operatorId(), holder);
+                }
+            }
+            return coordinatorMap;
         }
 
         @Override
@@ -1152,8 +1258,311 @@ public class DeclarativeSchedulerNG implements SchedulerNG {
             }
         }
 
-        public void updateAccumulators(AccumulatorSnapshot accumulatorSnapshot) {
+        private void updateAccumulators(AccumulatorSnapshot accumulatorSnapshot) {
             executionGraph.updateAccumulators(accumulatorSnapshot);
+        }
+
+        private KvStateLocation requestKvStateLocation(JobID jobId, String registrationName)
+                throws FlinkJobNotFoundException, UnknownKvStateLocation {
+            if (jobGraph.getJobID().equals(jobId)) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(
+                            "Lookup key-value state for job {} with registration " + "name {}.",
+                            jobGraph.getJobID(),
+                            registrationName);
+                }
+
+                final KvStateLocationRegistry registry =
+                        executionGraph.getKvStateLocationRegistry();
+                final KvStateLocation location = registry.getKvStateLocation(registrationName);
+                if (location != null) {
+                    return location;
+                } else {
+                    throw new UnknownKvStateLocation(registrationName);
+                }
+            } else {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(
+                            "Request of key-value state location for unknown job {} received.",
+                            jobId);
+                }
+                throw new FlinkJobNotFoundException(jobId);
+            }
+        }
+
+        private void notifyKvStateRegistered(
+                JobID jobId,
+                JobVertexID jobVertexId,
+                KeyGroupRange keyGroupRange,
+                String registrationName,
+                KvStateID kvStateId,
+                InetSocketAddress kvStateServerAddress)
+                throws FlinkJobNotFoundException {
+            if (jobGraph.getJobID().equals(jobId)) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(
+                            "Key value state registered for job {} under name {}.",
+                            jobGraph.getJobID(),
+                            registrationName);
+                }
+
+                try {
+                    executionGraph
+                            .getKvStateLocationRegistry()
+                            .notifyKvStateRegistered(
+                                    jobVertexId,
+                                    keyGroupRange,
+                                    registrationName,
+                                    kvStateId,
+                                    kvStateServerAddress);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            } else {
+                throw new FlinkJobNotFoundException(jobId);
+            }
+        }
+
+        private void notifyKvStateUnregistered(
+                JobID jobId,
+                JobVertexID jobVertexId,
+                KeyGroupRange keyGroupRange,
+                String registrationName)
+                throws FlinkJobNotFoundException {
+            if (jobGraph.getJobID().equals(jobId)) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(
+                            "Key value state unregistered for job {} under name {}.",
+                            jobGraph.getJobID(),
+                            registrationName);
+                }
+
+                try {
+                    executionGraph
+                            .getKvStateLocationRegistry()
+                            .notifyKvStateUnregistered(
+                                    jobVertexId, keyGroupRange, registrationName);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            } else {
+                throw new FlinkJobNotFoundException(jobId);
+            }
+        }
+
+        private Optional<OperatorBackPressureStats> requestOperatorBackPressureStats(
+                JobVertexID jobVertexId) throws FlinkException {
+            final ExecutionJobVertex jobVertex = executionGraph.getJobVertex(jobVertexId);
+
+            if (jobVertex == null) {
+                throw new FlinkException("JobVertexID not found " + jobVertexId);
+            }
+
+            return backPressureStatsTracker.getOperatorBackPressureStats(jobVertex);
+        }
+
+        private CompletableFuture<String> triggerSavepoint(
+                String targetDirectory, boolean cancelJob) {
+            final CheckpointCoordinator checkpointCoordinator =
+                    executionGraph.getCheckpointCoordinator();
+            if (checkpointCoordinator == null) {
+                throw new IllegalStateException(
+                        String.format("Job %s is not a streaming job.", jobGraph.getJobID()));
+            } else if (targetDirectory == null
+                    && !checkpointCoordinator
+                            .getCheckpointStorage()
+                            .hasDefaultSavepointLocation()) {
+                LOG.info(
+                        "Trying to cancel job {} with savepoint, but no savepoint directory configured.",
+                        jobGraph.getJobID());
+
+                throw new IllegalStateException(
+                        "No savepoint directory configured. You can either specify a directory "
+                                + "while cancelling via -s :targetDirectory or configure a cluster-wide "
+                                + "default via key '"
+                                + CheckpointingOptions.SAVEPOINT_DIRECTORY.key()
+                                + "'.");
+            }
+
+            LOG.info(
+                    "Triggering {}savepoint for job {}.",
+                    cancelJob ? "cancel-with-" : "",
+                    jobGraph.getJobID());
+
+            if (cancelJob) {
+                checkpointCoordinator.stopCheckpointScheduler();
+            }
+
+            return checkpointCoordinator
+                    .triggerSavepoint(targetDirectory)
+                    .thenApply(CompletedCheckpoint::getExternalPointer)
+                    .handleAsync(
+                            (path, throwable) -> {
+                                if (throwable != null) {
+                                    if (cancelJob && state == this) {
+                                        startCheckpointScheduler(checkpointCoordinator);
+                                    }
+                                    throw new CompletionException(throwable);
+                                } else if (cancelJob && state == this) {
+                                    LOG.info(
+                                            "Savepoint stored in {}. Now cancelling {}.",
+                                            path,
+                                            jobGraph.getJobID());
+                                    cancel();
+                                }
+                                return path;
+                            },
+                            componentMainThreadExecutor);
+        }
+
+        private CompletableFuture<String> stopWithSavepoint(
+                String targetDirectory, boolean advanceToEndOfEventTime) {
+            final CheckpointCoordinator checkpointCoordinator =
+                    executionGraph.getCheckpointCoordinator();
+
+            if (checkpointCoordinator == null) {
+                return FutureUtils.completedExceptionally(
+                        new IllegalStateException(
+                                String.format(
+                                        "Job %s is not a streaming job.", jobGraph.getJobID())));
+            }
+
+            if (targetDirectory == null
+                    && !checkpointCoordinator
+                            .getCheckpointStorage()
+                            .hasDefaultSavepointLocation()) {
+                LOG.info(
+                        "Trying to cancel job {} with savepoint, but no savepoint directory configured.",
+                        jobGraph.getJobID());
+
+                return FutureUtils.completedExceptionally(
+                        new IllegalStateException(
+                                "No savepoint directory configured. You can either specify a directory "
+                                        + "while cancelling via -s :targetDirectory or configure a cluster-wide "
+                                        + "default via key '"
+                                        + CheckpointingOptions.SAVEPOINT_DIRECTORY.key()
+                                        + "'."));
+            }
+
+            LOG.info("Triggering stop-with-savepoint for job {}.", jobGraph.getJobID());
+
+            // we stop the checkpoint coordinator so that we are guaranteed
+            // to have only the data of the synchronous savepoint committed.
+            // in case of failure, and if the job restarts, the coordinator
+            // will be restarted by the CheckpointCoordinatorDeActivator.
+            checkpointCoordinator.stopCheckpointScheduler();
+
+            final CompletableFuture<String> savepointFuture =
+                    checkpointCoordinator
+                            .triggerSynchronousSavepoint(advanceToEndOfEventTime, targetDirectory)
+                            .thenApply(CompletedCheckpoint::getExternalPointer);
+
+            final CompletableFuture<JobStatus> terminationFuture =
+                    executionGraph
+                            .getTerminationFuture()
+                            .handle(
+                                    (jobstatus, throwable) -> {
+                                        if (throwable != null) {
+                                            LOG.info(
+                                                    "Failed during stopping job {} with a savepoint. Reason: {}",
+                                                    jobGraph.getJobID(),
+                                                    throwable.getMessage());
+                                            throw new CompletionException(throwable);
+                                        } else if (jobstatus != JobStatus.FINISHED) {
+                                            LOG.info(
+                                                    "Failed during stopping job {} with a savepoint. Reason: Reached state {} instead of FINISHED.",
+                                                    jobGraph.getJobID(),
+                                                    jobstatus);
+                                            throw new CompletionException(
+                                                    new FlinkException(
+                                                            "Reached state "
+                                                                    + jobstatus
+                                                                    + " instead of FINISHED."));
+                                        }
+                                        return jobstatus;
+                                    });
+
+            return savepointFuture
+                    .thenCompose((path) -> terminationFuture.thenApply((jobStatus -> path)))
+                    .handleAsync(
+                            (path, throwable) -> {
+                                if (throwable != null) {
+                                    if (state == this) {
+                                        // restart the checkpoint coordinator if stopWithSavepoint
+                                        // failed.
+                                        startCheckpointScheduler(checkpointCoordinator);
+                                    }
+                                    throw new CompletionException(throwable);
+                                }
+
+                                return path;
+                            },
+                            componentMainThreadExecutor);
+        }
+
+        private void startCheckpointScheduler(final CheckpointCoordinator checkpointCoordinator) {
+            if (checkpointCoordinator.isPeriodicCheckpointingConfigured()) {
+                try {
+                    checkpointCoordinator.startCheckpointScheduler();
+                } catch (IllegalStateException ignored) {
+                    // Concurrent shut down of the coordinator
+                }
+            }
+        }
+
+        private Void deliverOperatorEventToCoordinator(
+                ExecutionAttemptID taskExecutionId, OperatorID operatorId, OperatorEvent evt)
+                throws FlinkException {
+            // Failure semantics (as per the javadocs of the method):
+            // If the task manager sends an event for a non-running task or an non-existing operator
+            // coordinator, then respond with an exception to the call. If task and coordinator
+            // exist,
+            // then we assume that the call from the TaskManager was valid, and any bubbling
+            // exception
+            // needs to cause a job failure.
+
+            final Execution exec = executionGraph.getRegisteredExecutions().get(taskExecutionId);
+            if (exec == null || exec.getState() != ExecutionState.RUNNING) {
+                // This situation is common when cancellation happens, or when the task failed while
+                // the
+                // event was just being dispatched asynchronously on the TM side.
+                // It should be fine in those expected situations to just ignore this event, but, to
+                // be
+                // on the safe, we notify the TM that the event could not be delivered.
+                throw new TaskNotRunningException(
+                        "Task is not known or in state running on the JobManager.");
+            }
+
+            final OperatorCoordinatorHolder coordinator = coordinatorMap.get(operatorId);
+            if (coordinator == null) {
+                throw new FlinkException("No coordinator registered for operator " + operatorId);
+            }
+
+            try {
+                coordinator.handleEventFromOperator(exec.getParallelSubtaskIndex(), evt);
+            } catch (Throwable t) {
+                ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
+                DeclarativeSchedulerNG.this.handleGlobalFailure(t);
+            }
+
+            return null;
+        }
+
+        private CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
+                OperatorID operator, CoordinationRequest request) throws FlinkException {
+            final OperatorCoordinatorHolder coordinatorHolder = coordinatorMap.get(operator);
+            if (coordinatorHolder == null) {
+                throw new FlinkException("Coordinator of operator " + operator + " does not exist");
+            }
+
+            final OperatorCoordinator coordinator = coordinatorHolder.coordinator();
+            if (coordinator instanceof CoordinationRequestHandler) {
+                return ((CoordinationRequestHandler) coordinator)
+                        .handleCoordinationRequest(request);
+            } else {
+                throw new FlinkException(
+                        "Coordinator of operator " + operator + " cannot handle client event");
+            }
         }
 
         abstract StateAndBoolean updateTaskExecutionState(
@@ -1187,16 +1596,20 @@ public class DeclarativeSchedulerNG implements SchedulerNG {
             }
         }
 
-        default <T> void tryRun(Class<? extends T> clazz, Consumer<T> action, String debugMessage) {
-            OptionalConsumer.of(as(clazz))
-                    .ifPresent(action::accept)
-                    .ifNotPresent(
-                            () ->
-                                    LOG.debug(
-                                            "Cannot run '{}' because the actual state is {} and not {}.",
-                                            debugMessage,
-                                            this.getClass().getSimpleName(),
-                                            clazz.getSimpleName()));
+        default <T, E extends Exception> void tryRun(
+                Class<? extends T> clazz, ThrowingConsumer<T, E> action, String debugMessage)
+                throws E {
+            final Optional<? extends T> asOptional = as(clazz);
+
+            if (asOptional.isPresent()) {
+                action.accept(asOptional.get());
+            } else {
+                LOG.debug(
+                        "Cannot run '{}' because the actual state is {} and not {}.",
+                        debugMessage,
+                        this.getClass().getSimpleName(),
+                        clazz.getSimpleName());
+            }
         }
 
         default <T, V, E extends Exception> Optional<V> tryCall(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerNG.java
@@ -1,0 +1,1192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.core.io.InputSplit;
+import org.apache.flink.queryablestate.KvStateID;
+import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
+import org.apache.flink.runtime.blob.BlobWriter;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
+import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionDeploymentListener;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphBuilder;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionStateUpdateListener;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.IntermediateResult;
+import org.apache.flink.runtime.executiongraph.JobStatusListener;
+import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
+import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
+import org.apache.flink.runtime.jobmanager.scheduler.Locality;
+import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
+import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTrackerDeploymentListenerAdapter;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SerializedInputSplit;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPool;
+import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlot;
+import org.apache.flink.runtime.jobmaster.slotpool.ResourceCounter;
+import org.apache.flink.runtime.jobmaster.slotpool.SingleLogicalSlot;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
+import org.apache.flink.runtime.jobmaster.slotpool.ThrowingSlotProvider;
+import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
+import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.runtime.query.KvStateLocation;
+import org.apache.flink.runtime.query.UnknownKvStateLocation;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
+import org.apache.flink.runtime.scheduler.SchedulerNG;
+import org.apache.flink.runtime.scheduler.SchedulerUtils;
+import org.apache.flink.runtime.scheduler.UpdateSchedulerNgOnInternalFailuresListener;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.OptionalConsumer;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.FunctionWithException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/** Declarative scheduler ng. */
+public class DeclarativeSchedulerNG implements SchedulerNG {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DeclarativeSchedulerNG.class);
+
+    private final JobGraph jobGraph;
+
+    private final DeclarativeSlotPool declarativeSlotPool;
+
+    private final long initializationTimestamp;
+
+    private final Configuration configuration;
+    private final ScheduledExecutorService futureExecutor;
+    private final Executor ioExecutor;
+    private final ClassLoader userCodeClassLoader;
+    private final Time rpcTimeout;
+    private final BlobWriter blobWriter;
+    private final ShuffleMaster<?> shuffleMaster;
+    private final JobMasterPartitionTracker partitionTracker;
+    private final ExecutionDeploymentTracker executionDeploymentTracker;
+    private final JobManagerJobMetricGroup jobManagerJobMetricGroup;
+
+    private final CompletedCheckpointStore completedCheckpointStore;
+    private final CheckpointIDCounter checkpointIdCounter;
+    private final CheckpointsCleaner checkpointsCleaner;
+
+    private final CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
+
+    private ComponentMainThreadExecutor componentMainThreadExecutor =
+            new ComponentMainThreadExecutor.DummyComponentMainThreadExecutor("foobar");
+
+    @Nullable private JobStatusListener jobStatusListener;
+
+    private State state = new Created();
+
+    public DeclarativeSchedulerNG(
+            JobGraph jobGraph,
+            Configuration configuration,
+            Logger log,
+            DeclarativeSlotPool declarativeSlotPool,
+            ScheduledExecutorService futureExecutor,
+            Executor ioExecutor,
+            ClassLoader userCodeClassLoader,
+            CheckpointRecoveryFactory checkpointRecoveryFactory,
+            Time rpcTimeout,
+            BlobWriter blobWriter,
+            JobManagerJobMetricGroup jobManagerJobMetricGroup,
+            ShuffleMaster<?> shuffleMaster,
+            JobMasterPartitionTracker partitionTracker,
+            ExecutionDeploymentTracker executionDeploymentTracker,
+            long initializationTimestamp)
+            throws JobExecutionException {
+
+        this.jobGraph = jobGraph;
+        this.declarativeSlotPool = declarativeSlotPool;
+        this.initializationTimestamp = initializationTimestamp;
+        this.configuration = configuration;
+        this.futureExecutor = futureExecutor;
+        this.ioExecutor = ioExecutor;
+        this.userCodeClassLoader = userCodeClassLoader;
+        this.rpcTimeout = rpcTimeout;
+        this.blobWriter = blobWriter;
+        this.shuffleMaster = shuffleMaster;
+        this.partitionTracker = partitionTracker;
+        this.executionDeploymentTracker = executionDeploymentTracker;
+        this.jobManagerJobMetricGroup = jobManagerJobMetricGroup;
+        this.completedCheckpointStore =
+                SchedulerUtils.createCompletedCheckpointStoreIfCheckpointingIsEnabled(
+                        jobGraph,
+                        configuration,
+                        userCodeClassLoader,
+                        checkpointRecoveryFactory,
+                        LOG);
+        this.checkpointIdCounter =
+                SchedulerUtils.createCheckpointIDCounterIfCheckpointingIsEnabled(
+                        jobGraph, checkpointRecoveryFactory);
+        this.checkpointsCleaner = new CheckpointsCleaner();
+
+        declarativeSlotPool.registerNewSlotsListener(this::newResourcesAvailable);
+    }
+
+    private void newResourcesAvailable(Collection<? extends PhysicalSlot> physicalSlots) {
+        state.tryRun(
+                ResourceConsumer.class,
+                ResourceConsumer::newResourcesAvailable,
+                "newResourcesAvailable");
+    }
+
+    private void stopCheckpointServicesSafely(JobStatus terminalState) {
+        Exception exception = null;
+
+        try {
+            completedCheckpointStore.shutdown(terminalState, checkpointsCleaner, () -> {});
+        } catch (Exception e) {
+            exception = e;
+        }
+
+        try {
+            checkpointIdCounter.shutdown(terminalState);
+        } catch (Exception e) {
+            exception = ExceptionUtils.firstOrSuppressed(e, exception);
+        }
+
+        if (exception != null) {
+            LOG.warn("Failed to stop checkpoint services.", exception);
+        }
+    }
+
+    @Nonnull
+    private ArchivedExecutionGraph createArchivedExecutionGraph(
+            JobStatus jobStatus, @Nullable Throwable throwable) {
+        return ArchivedExecutionGraph.createFromInitializingJob(
+                jobGraph.getJobID(),
+                jobGraph.getName(),
+                jobStatus,
+                throwable,
+                initializationTimestamp);
+    }
+
+    private ResourceCounter calculateDesiredResources() {
+        int counter = 0;
+
+        for (JobVertex vertex : jobGraph.getVertices()) {
+            counter += vertex.getParallelism();
+        }
+
+        return ResourceCounter.withResource(ResourceProfile.UNKNOWN, counter);
+    }
+
+    private ExecutionGraph createExecutionGraphAndRestoreState() throws Exception {
+        ExecutionDeploymentListener executionDeploymentListener =
+                new ExecutionDeploymentTrackerDeploymentListenerAdapter(executionDeploymentTracker);
+        ExecutionStateUpdateListener executionStateUpdateListener =
+                (execution, newState) -> {
+                    if (newState.isTerminal()) {
+                        executionDeploymentTracker.stopTrackingDeploymentOf(execution);
+                    }
+                };
+
+        final ExecutionGraph newExecutionGraph =
+                ExecutionGraphBuilder.buildGraph(
+                        jobGraph,
+                        configuration,
+                        futureExecutor,
+                        ioExecutor,
+                        new ThrowingSlotProvider(),
+                        userCodeClassLoader,
+                        completedCheckpointStore,
+                        checkpointsCleaner,
+                        checkpointIdCounter,
+                        rpcTimeout,
+                        jobManagerJobMetricGroup,
+                        blobWriter,
+                        Time.milliseconds(0L),
+                        LOG,
+                        shuffleMaster,
+                        partitionTracker,
+                        executionDeploymentListener,
+                        executionStateUpdateListener,
+                        initializationTimestamp);
+
+        final CheckpointCoordinator checkpointCoordinator =
+                newExecutionGraph.getCheckpointCoordinator();
+
+        if (checkpointCoordinator != null) {
+            // check whether we find a valid checkpoint
+            if (!checkpointCoordinator.restoreInitialCheckpointIfPresent(
+                    new HashSet<>(newExecutionGraph.getAllVertices().values()))) {
+
+                // check whether we can restore from a savepoint
+                tryRestoreExecutionGraphFromSavepoint(
+                        newExecutionGraph, jobGraph.getSavepointRestoreSettings());
+            }
+        }
+
+        return newExecutionGraph;
+    }
+
+    /**
+     * Tries to restore the given {@link ExecutionGraph} from the provided {@link
+     * SavepointRestoreSettings}.
+     *
+     * @param executionGraphToRestore {@link ExecutionGraph} which is supposed to be restored
+     * @param savepointRestoreSettings {@link SavepointRestoreSettings} containing information about
+     *     the savepoint to restore from
+     * @throws Exception if the {@link ExecutionGraph} could not be restored
+     */
+    private void tryRestoreExecutionGraphFromSavepoint(
+            ExecutionGraph executionGraphToRestore,
+            SavepointRestoreSettings savepointRestoreSettings)
+            throws Exception {
+        if (savepointRestoreSettings.restoreSavepoint()) {
+            final CheckpointCoordinator checkpointCoordinator =
+                    executionGraphToRestore.getCheckpointCoordinator();
+            if (checkpointCoordinator != null) {
+                checkpointCoordinator.restoreSavepoint(
+                        savepointRestoreSettings.getRestorePath(),
+                        savepointRestoreSettings.allowNonRestoredState(),
+                        executionGraphToRestore.getAllVertices(),
+                        userCodeClassLoader);
+            }
+        }
+    }
+
+    private String retrieveTaskManagerLocation(
+            ExecutionGraph executionGraph, ExecutionAttemptID executionAttemptID) {
+        final Optional<Execution> currentExecution =
+                Optional.ofNullable(
+                        executionGraph.getRegisteredExecutions().get(executionAttemptID));
+
+        return currentExecution
+                .map(Execution::getAssignedResourceLocation)
+                .map(TaskManagerLocation::toString)
+                .orElse("Unknown location");
+    }
+
+    @Override
+    public void initialize(ComponentMainThreadExecutor mainThreadExecutor) {
+        this.componentMainThreadExecutor = mainThreadExecutor;
+    }
+
+    @Override
+    public void registerJobStatusListener(JobStatusListener jobStatusListener) {
+        this.jobStatusListener = jobStatusListener;
+    }
+
+    @Override
+    public void startScheduling() {
+        transitionToState(
+                state.as(Created.class)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Can only start scheduling when being in Created state."))
+                        .startScheduling());
+    }
+
+    @Override
+    public void suspend(Throwable cause) {
+        transitionToState(state.suspend(cause));
+    }
+
+    @Override
+    public void cancel() {
+        transitionToState(state.cancel());
+    }
+
+    @Override
+    public CompletableFuture<Void> getTerminationFuture() {
+        return terminationFuture;
+    }
+
+    @Override
+    public void handleGlobalFailure(Throwable cause) {}
+
+    @Override
+    public boolean updateTaskExecutionState(TaskExecutionStateTransition taskExecutionState) {
+        final Optional<StateAndBoolean> optionalResult =
+                state.tryCall(
+                        StateWithExecutionGraph.class,
+                        stateWithExecutionGraph ->
+                                stateWithExecutionGraph.updateTaskExecutionState(
+                                        taskExecutionState),
+                        "updateTaskExecutionState");
+
+        if (optionalResult.isPresent()) {
+            transitionToState(optionalResult.get().getState());
+            return optionalResult.get().getResult();
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public SerializedInputSplit requestNextInputSplit(
+            JobVertexID vertexID, ExecutionAttemptID executionAttempt) throws IOException {
+        return state.tryCall(
+                        StateWithExecutionGraph.class,
+                        stateWithExecutionGraph ->
+                                stateWithExecutionGraph.requestNextInputSplit(
+                                        vertexID, executionAttempt),
+                        "requestNextInputSplit")
+                .orElseThrow(
+                        () -> new IOException("Scheduler is currently not executing the job."));
+    }
+
+    @Override
+    public ExecutionState requestPartitionState(
+            IntermediateDataSetID intermediateResultId, ResultPartitionID resultPartitionId)
+            throws PartitionProducerDisposedException {
+        return state.tryCall(
+                        StateWithExecutionGraph.class,
+                        stateWithExecutionGraph ->
+                                stateWithExecutionGraph.requestPartitionState(
+                                        intermediateResultId, resultPartitionId),
+                        "requestPartitionState")
+                .orElseThrow(() -> new PartitionProducerDisposedException(resultPartitionId));
+    }
+
+    @Override
+    public void notifyPartitionDataAvailable(ResultPartitionID partitionID) {
+        state.tryRun(
+                StateWithExecutionGraph.class,
+                stateWithExecutionGraph ->
+                        stateWithExecutionGraph.notifyPartitionDataAvailable(partitionID),
+                "notifyPartitionDataAvailable");
+    }
+
+    @Override
+    public ArchivedExecutionGraph requestJob() {
+        return state.getJob();
+    }
+
+    @Override
+    public JobStatus requestJobStatus() {
+        return state.getJobStatus();
+    }
+
+    @Override
+    public JobDetails requestJobDetails() {
+        return JobDetails.createDetailsForJob(state.getJob());
+    }
+
+    @Override
+    public KvStateLocation requestKvStateLocation(JobID jobId, String registrationName)
+            throws UnknownKvStateLocation, FlinkJobNotFoundException {
+        return null;
+    }
+
+    @Override
+    public void notifyKvStateRegistered(
+            JobID jobId,
+            JobVertexID jobVertexId,
+            KeyGroupRange keyGroupRange,
+            String registrationName,
+            KvStateID kvStateId,
+            InetSocketAddress kvStateServerAddress)
+            throws FlinkJobNotFoundException {}
+
+    @Override
+    public void notifyKvStateUnregistered(
+            JobID jobId,
+            JobVertexID jobVertexId,
+            KeyGroupRange keyGroupRange,
+            String registrationName)
+            throws FlinkJobNotFoundException {}
+
+    @Override
+    public void updateAccumulators(AccumulatorSnapshot accumulatorSnapshot) {
+        state.tryRun(
+                StateWithExecutionGraph.class,
+                stateWithExecutionGraph ->
+                        stateWithExecutionGraph.updateAccumulators(accumulatorSnapshot),
+                "updateAccumulators");
+    }
+
+    @Override
+    public Optional<OperatorBackPressureStats> requestOperatorBackPressureStats(
+            JobVertexID jobVertexId) throws FlinkException {
+        return Optional.empty();
+    }
+
+    @Override
+    public CompletableFuture<String> triggerSavepoint(
+            @Nullable String targetDirectory, boolean cancelJob) {
+        return null;
+    }
+
+    @Override
+    public void acknowledgeCheckpoint(
+            JobID jobID,
+            ExecutionAttemptID executionAttemptID,
+            long checkpointId,
+            CheckpointMetrics checkpointMetrics,
+            TaskStateSnapshot checkpointState) {
+        state.tryRun(
+                StateWithExecutionGraph.class,
+                stateWithExecutionGraph ->
+                        stateWithExecutionGraph.acknowledgeCheckpoint(
+                                jobID,
+                                executionAttemptID,
+                                checkpointId,
+                                checkpointMetrics,
+                                checkpointState),
+                "acknowledgeCheckpoint");
+    }
+
+    @Override
+    public void declineCheckpoint(DeclineCheckpoint decline) {
+        state.tryRun(
+                StateWithExecutionGraph.class,
+                stateWithExecutionGraph -> stateWithExecutionGraph.declineCheckpoint(decline),
+                "declineCheckpoint");
+    }
+
+    @Override
+    public CompletableFuture<String> stopWithSavepoint(
+            String targetDirectory, boolean advanceToEndOfEventTime) {
+        return null;
+    }
+
+    @Override
+    public void deliverOperatorEventToCoordinator(
+            ExecutionAttemptID taskExecution, OperatorID operator, OperatorEvent evt)
+            throws FlinkException {}
+
+    @Override
+    public CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
+            OperatorID operator, CoordinationRequest request) throws FlinkException {
+        return null;
+    }
+
+    // ----------------------------------------------------------------
+
+    private void transitionToState(State newState) {
+        if (state != newState) {
+            LOG.debug(
+                    "Transition from state {} to {}.",
+                    state.getClass().getSimpleName(),
+                    newState.getClass().getSimpleName());
+            state = newState;
+        }
+    }
+
+    private void runIfState(State expectedState, Runnable action) {
+        runIfState(expectedState, action, 0L, TimeUnit.SECONDS);
+    }
+
+    private void runIfState(State expectedState, Runnable action, long delay, TimeUnit timeUnit) {
+        componentMainThreadExecutor.schedule(
+                () -> {
+                    if (state == expectedState) {
+                        action.run();
+                    } else {
+                        LOG.debug(
+                                "Ignoring scheduled action because expected state {} is not the actual state {}.",
+                                expectedState,
+                                state);
+                    }
+                },
+                delay,
+                timeUnit);
+    }
+
+    // ----------------------------------------------------------------
+
+    private final class Created implements State {
+
+        @Override
+        public State cancel() {
+            return new Finished(createArchivedExecutionGraph(JobStatus.CANCELED, null));
+        }
+
+        @Override
+        public State suspend(Throwable cause) {
+            return new Finished(createArchivedExecutionGraph(JobStatus.SUSPENDED, cause));
+        }
+
+        @Override
+        public JobStatus getJobStatus() {
+            return JobStatus.INITIALIZING;
+        }
+
+        @Override
+        public ArchivedExecutionGraph getJob() {
+            return createArchivedExecutionGraph(getJobStatus(), null);
+        }
+
+        WaitingForResources startScheduling() {
+            final ResourceCounter desiredResources = calculateDesiredResources();
+            declarativeSlotPool.increaseResourceRequirementsBy(desiredResources);
+
+            return new WaitingForResources(desiredResources);
+        }
+    }
+
+    private final class WaitingForResources implements State, ResourceConsumer {
+
+        private final ResourceCounter desiredResources;
+
+        private WaitingForResources(ResourceCounter desiredResources) {
+            this.desiredResources = desiredResources;
+
+            runIfState(this, this::newResourcesAvailable);
+
+            // register timeout
+            runIfState(this, this::resourceTimeout, 10L, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public State cancel() {
+            return new Finished(createArchivedExecutionGraph(JobStatus.CANCELED, null));
+        }
+
+        @Override
+        public State suspend(Throwable cause) {
+            return new Finished(createArchivedExecutionGraph(JobStatus.SUSPENDED, cause));
+        }
+
+        @Override
+        public JobStatus getJobStatus() {
+            return JobStatus.INITIALIZING;
+        }
+
+        @Override
+        public ArchivedExecutionGraph getJob() {
+            return createArchivedExecutionGraph(JobStatus.INITIALIZING, null);
+        }
+
+        @Override
+        public void newResourcesAvailable() {
+            if (hasEnoughResources()) {
+                transitionToState(createExecutionGraphWithAvailableResources());
+            }
+        }
+
+        private void resourceTimeout() {
+            transitionToState(createExecutionGraphWithAvailableResources());
+        }
+
+        private boolean hasEnoughResources() {
+            final Collection<? extends SlotInfo> allSlots =
+                    declarativeSlotPool.getFreeSlotsInformation();
+            ResourceCounter outstandingResources = desiredResources;
+
+            final Iterator<? extends SlotInfo> slotIterator = allSlots.iterator();
+
+            while (!outstandingResources.isEmpty() && slotIterator.hasNext()) {
+                final SlotInfo slotInfo = slotIterator.next();
+                final ResourceProfile resourceProfile = slotInfo.getResourceProfile();
+
+                if (outstandingResources.containsResource(resourceProfile)) {
+                    outstandingResources = outstandingResources.subtract(resourceProfile, 1);
+                } else {
+                    outstandingResources =
+                            outstandingResources.subtract(ResourceProfile.UNKNOWN, 1);
+                }
+            }
+
+            return outstandingResources.isEmpty();
+        }
+
+        private State createExecutionGraphWithAvailableResources() {
+            try {
+                final ExecutionGraph executionGraph = createExecutionGraphAndAssignResources();
+
+                return new Executing(executionGraph);
+            } catch (Exception exception) {
+                return new Finished(createArchivedExecutionGraph(JobStatus.FAILED, exception));
+            }
+        }
+
+        private DeclarativeScheduler.ParallelismAndResourceAssignments
+                determineParallelismAndAssignResources(JobGraph jobGraph) {
+            final HashMap<ExecutionVertexID, LogicalSlot> assignedSlots = new HashMap<>();
+            final HashMap<JobVertexID, Integer> parallelismPerJobVertex = new HashMap<>();
+
+            final Collection<SlotInfoWithUtilization> freeSlots =
+                    declarativeSlotPool.getFreeSlotsInformation();
+            final int slotsPerVertex = freeSlots.size() / jobGraph.getNumberOfVertices();
+            final Iterator<SlotInfoWithUtilization> slotIterator = freeSlots.iterator();
+
+            for (JobVertex jobVertex : jobGraph.getVerticesSortedTopologicallyFromSources()) {
+                final int parallelism = Math.min(jobVertex.getParallelism(), slotsPerVertex);
+                jobVertex.setParallelism(parallelism);
+
+                parallelismPerJobVertex.put(jobVertex.getID(), parallelism);
+
+                for (int i = 0; i < slotsPerVertex; i++) {
+                    final SlotInfoWithUtilization slotInfo = slotIterator.next();
+
+                    final PhysicalSlot physicalSlot =
+                            declarativeSlotPool.reserveFreeSlot(
+                                    slotInfo.getAllocationId(),
+                                    ResourceProfile.fromResourceSpec(
+                                            jobVertex.getMinResources(), MemorySize.ZERO));
+
+                    final SingleLogicalSlot logicalSlot =
+                            new SingleLogicalSlot(
+                                    new SlotRequestId(),
+                                    physicalSlot,
+                                    null,
+                                    Locality.UNKNOWN,
+                                    slot ->
+                                            declarativeSlotPool.freeReservedSlot(
+                                                    physicalSlot.getAllocationId(),
+                                                    null,
+                                                    System.currentTimeMillis()));
+                    physicalSlot.tryAssignPayload(logicalSlot);
+
+                    assignedSlots.put(new ExecutionVertexID(jobVertex.getID(), i), logicalSlot);
+                }
+            }
+
+            return new DeclarativeScheduler.ParallelismAndResourceAssignments(
+                    assignedSlots, parallelismPerJobVertex);
+        }
+
+        @Nonnull
+        private ExecutionGraph createExecutionGraphAndAssignResources() throws Exception {
+            final DeclarativeScheduler.ParallelismAndResourceAssignments
+                    parallelismAndResourceAssignments =
+                            determineParallelismAndAssignResources(jobGraph);
+
+            for (JobVertex vertex : jobGraph.getVertices()) {
+                vertex.setParallelism(
+                        parallelismAndResourceAssignments.getParallelism(vertex.getID()));
+            }
+
+            final ExecutionGraph executionGraph = createExecutionGraphAndRestoreState();
+
+            executionGraph.start(componentMainThreadExecutor);
+            executionGraph.transitionToRunning();
+
+            executionGraph.setInternalTaskFailuresListener(
+                    new UpdateSchedulerNgOnInternalFailuresListener(
+                            DeclarativeSchedulerNG.this, jobGraph.getJobID()));
+
+            for (ExecutionVertex executionVertex : executionGraph.getAllExecutionVertices()) {
+                final LogicalSlot assignedSlot =
+                        parallelismAndResourceAssignments.getAssignedSlot(executionVertex.getID());
+                executionVertex.tryAssignResource(assignedSlot);
+            }
+            return executionGraph;
+        }
+    }
+
+    private final class Executing extends StateWithExecutionGraph {
+
+        private Executing(ExecutionGraph executionGraph) {
+            super(executionGraph);
+
+            runIfState(this, this::deploy);
+        }
+
+        @Override
+        public State cancel() {
+            return new Canceling(executionGraph);
+        }
+
+        @Override
+        StateAndBoolean updateTaskExecutionState(TaskExecutionStateTransition taskExecutionState) {
+            final boolean successfulUpdate = executionGraph.updateState(taskExecutionState);
+
+            if (successfulUpdate) {
+                if (taskExecutionState.getExecutionState() == ExecutionState.FAILED) {
+                    return StateAndBoolean.create(new Restarting(executionGraph), true);
+                } else {
+                    return StateAndBoolean.create(this, true);
+                }
+            } else {
+                return StateAndBoolean.create(this, false);
+            }
+        }
+
+        @Override
+        void onTerminalState(JobStatus jobStatus) {
+            transitionToState(new Finished(ArchivedExecutionGraph.createFrom(executionGraph)));
+        }
+
+        private void deploy() {
+            for (ExecutionVertex executionVertex : executionGraph.getAllExecutionVertices()) {
+                deploySafely(executionVertex);
+            }
+        }
+
+        private void deploySafely(ExecutionVertex executionVertex) {
+            try {
+                executionVertex.deploy();
+            } catch (JobException e) {
+                handleDeploymentFailure(executionVertex, e);
+            }
+        }
+
+        private void handleDeploymentFailure(ExecutionVertex executionVertex, JobException e) {
+            executionVertex.markFailed(e);
+        }
+    }
+
+    private final class Restarting extends StateWithExecutionGraph {
+
+        private Restarting(ExecutionGraph executionGraph) {
+            super(executionGraph);
+            executionGraph.cancel();
+        }
+
+        @Override
+        public State cancel() {
+            return new Canceling(executionGraph);
+        }
+
+        @Override
+        StateAndBoolean updateTaskExecutionState(TaskExecutionStateTransition taskExecutionState) {
+            final boolean successfulUpdate = executionGraph.updateState(taskExecutionState);
+
+            if (successfulUpdate) {
+                return StateAndBoolean.create(this, true);
+            } else {
+                return StateAndBoolean.create(this, false);
+            }
+        }
+
+        @Override
+        void onTerminalState(JobStatus jobStatus) {
+            Preconditions.checkArgument(jobStatus == JobStatus.CANCELED);
+
+            transitionToState(new WaitingForResources(calculateDesiredResources()));
+        }
+    }
+
+    private final class Canceling extends StateWithExecutionGraph {
+
+        private Canceling(ExecutionGraph executionGraph) {
+            super(executionGraph);
+            executionGraph.cancel();
+        }
+
+        @Override
+        public State cancel() {
+            return this;
+        }
+
+        @Override
+        StateAndBoolean updateTaskExecutionState(TaskExecutionStateTransition taskExecutionState) {
+            final boolean successfulUpdate = executionGraph.updateState(taskExecutionState);
+
+            if (successfulUpdate) {
+                return StateAndBoolean.create(this, true);
+            } else {
+                return StateAndBoolean.create(this, false);
+            }
+        }
+
+        @Override
+        void onTerminalState(JobStatus jobStatus) {
+            // not sure whether FAILED can or cannot happen here
+            Preconditions.checkArgument(
+                    jobStatus == JobStatus.CANCELED || jobStatus == JobStatus.FAILED);
+
+            transitionToState(new Finished(ArchivedExecutionGraph.createFrom(executionGraph)));
+        }
+    }
+
+    private final class Finished implements State {
+
+        private final ArchivedExecutionGraph archivedExecutionGraph;
+
+        private Finished(ArchivedExecutionGraph archivedExecutionGraph) {
+            this.archivedExecutionGraph = archivedExecutionGraph;
+
+            // set declared resources to 0
+            // declarativeSlotPool.decreaseResourceRequirementsBy(0);
+
+            runIfState(this, this::processFinishedState);
+        }
+
+        private void processFinishedState() {
+            stopCheckpointServicesSafely(archivedExecutionGraph.getState());
+
+            if (jobStatusListener != null) {
+                jobStatusListener.jobStatusChanges(
+                        jobGraph.getJobID(),
+                        archivedExecutionGraph.getState(),
+                        archivedExecutionGraph.getStatusTimestamp(
+                                archivedExecutionGraph.getState()),
+                        archivedExecutionGraph.getFailureInfo() != null
+                                ? archivedExecutionGraph.getFailureInfo().getException()
+                                : null);
+            }
+        }
+
+        @Override
+        public State cancel() {
+            return this;
+        }
+
+        @Override
+        public State suspend(Throwable cause) {
+            return this;
+        }
+
+        @Override
+        public JobStatus getJobStatus() {
+            return archivedExecutionGraph.getState();
+        }
+
+        @Override
+        public ArchivedExecutionGraph getJob() {
+            return archivedExecutionGraph;
+        }
+    }
+
+    private static class StateAndBoolean {
+        private final State state;
+        private final boolean result;
+
+        private StateAndBoolean(State state, boolean result) {
+            this.state = state;
+            this.result = result;
+        }
+
+        public static StateAndBoolean create(State state, boolean result) {
+            return new StateAndBoolean(state, result);
+        }
+
+        public State getState() {
+            return state;
+        }
+
+        public boolean getResult() {
+            return result;
+        }
+    }
+
+    private abstract class StateWithExecutionGraph implements State {
+        protected final ExecutionGraph executionGraph;
+
+        protected StateWithExecutionGraph(ExecutionGraph executionGraph) {
+            this.executionGraph = executionGraph;
+
+            executionGraph
+                    .getTerminationFuture()
+                    .thenAcceptAsync(
+                            jobStatus -> {
+                                if (state == this) {
+                                    onTerminalState(jobStatus);
+                                }
+                            },
+                            componentMainThreadExecutor);
+        }
+
+        @Override
+        public State suspend(Throwable cause) {
+            executionGraph.suspend(cause);
+            Preconditions.checkState(executionGraph.getState() == JobStatus.SUSPENDED);
+            return new Finished(ArchivedExecutionGraph.createFrom(executionGraph));
+        }
+
+        @Override
+        public JobStatus getJobStatus() {
+            return executionGraph.getState();
+        }
+
+        @Override
+        public ArchivedExecutionGraph getJob() {
+            return ArchivedExecutionGraph.createFrom(executionGraph);
+        }
+
+        void notifyPartitionDataAvailable(ResultPartitionID partitionID) {
+            executionGraph.notifyPartitionDataAvailable(partitionID);
+        }
+
+        SerializedInputSplit requestNextInputSplit(
+                JobVertexID vertexID, ExecutionAttemptID executionAttempt) throws IOException {
+            final Execution execution =
+                    executionGraph.getRegisteredExecutions().get(executionAttempt);
+            if (execution == null) {
+                // can happen when JobManager had already unregistered this execution upon on task
+                // failure,
+                // but TaskManager get some delay to aware of that situation
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Can not find Execution for attempt {}.", executionAttempt);
+                }
+                // but we should TaskManager be aware of this
+                throw new IllegalArgumentException(
+                        "Can not find Execution for attempt " + executionAttempt);
+            }
+
+            final ExecutionJobVertex vertex = executionGraph.getJobVertex(vertexID);
+            if (vertex == null) {
+                throw new IllegalArgumentException(
+                        "Cannot find execution vertex for vertex ID " + vertexID);
+            }
+
+            if (vertex.getSplitAssigner() == null) {
+                throw new IllegalStateException("No InputSplitAssigner for vertex ID " + vertexID);
+            }
+
+            final InputSplit nextInputSplit = execution.getNextInputSplit();
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Send next input split {}.", nextInputSplit);
+            }
+
+            try {
+                final byte[] serializedInputSplit =
+                        InstantiationUtil.serializeObject(nextInputSplit);
+                return new SerializedInputSplit(serializedInputSplit);
+            } catch (Exception ex) {
+                IOException reason =
+                        new IOException(
+                                "Could not serialize the next input split of class "
+                                        + nextInputSplit.getClass()
+                                        + ".",
+                                ex);
+                vertex.fail(reason);
+                throw reason;
+            }
+        }
+
+        abstract StateAndBoolean updateTaskExecutionState(
+                TaskExecutionStateTransition taskExecutionState);
+
+        abstract void onTerminalState(JobStatus jobStatus);
+
+        public ExecutionState requestPartitionState(
+                IntermediateDataSetID intermediateResultId, ResultPartitionID resultPartitionId)
+                throws PartitionProducerDisposedException {
+            final Execution execution =
+                    executionGraph.getRegisteredExecutions().get(resultPartitionId.getProducerId());
+            if (execution != null) {
+                return execution.getState();
+            } else {
+                final IntermediateResult intermediateResult =
+                        executionGraph.getAllIntermediateResults().get(intermediateResultId);
+
+                if (intermediateResult != null) {
+                    // Try to find the producing execution
+                    Execution producerExecution =
+                            intermediateResult
+                                    .getPartitionById(resultPartitionId.getPartitionId())
+                                    .getProducer()
+                                    .getCurrentExecutionAttempt();
+
+                    if (producerExecution
+                            .getAttemptId()
+                            .equals(resultPartitionId.getProducerId())) {
+                        return producerExecution.getState();
+                    } else {
+                        throw new PartitionProducerDisposedException(resultPartitionId);
+                    }
+                } else {
+                    throw new IllegalArgumentException(
+                            "Intermediate data set with ID "
+                                    + intermediateResultId
+                                    + " not found.");
+                }
+            }
+        }
+
+        private void acknowledgeCheckpoint(
+                JobID jobID,
+                ExecutionAttemptID executionAttemptID,
+                long checkpointId,
+                CheckpointMetrics checkpointMetrics,
+                TaskStateSnapshot checkpointState) {
+
+            final CheckpointCoordinator checkpointCoordinator =
+                    executionGraph.getCheckpointCoordinator();
+            final AcknowledgeCheckpoint ackMessage =
+                    new AcknowledgeCheckpoint(
+                            jobID,
+                            executionAttemptID,
+                            checkpointId,
+                            checkpointMetrics,
+                            checkpointState);
+
+            final String taskManagerLocationInfo =
+                    retrieveTaskManagerLocation(executionGraph, executionAttemptID);
+
+            if (checkpointCoordinator != null) {
+                ioExecutor.execute(
+                        () -> {
+                            try {
+                                checkpointCoordinator.receiveAcknowledgeMessage(
+                                        ackMessage, taskManagerLocationInfo);
+                            } catch (Throwable t) {
+                                LOG.warn(
+                                        "Error while processing checkpoint acknowledgement message",
+                                        t);
+                            }
+                        });
+            } else {
+                String errorMessage =
+                        "Received AcknowledgeCheckpoint message for job {} with no CheckpointCoordinator";
+                if (executionGraph.getState() == JobStatus.RUNNING) {
+                    LOG.error(errorMessage, jobGraph.getJobID());
+                } else {
+                    LOG.debug(errorMessage, jobGraph.getJobID());
+                }
+            }
+        }
+
+        private void declineCheckpoint(DeclineCheckpoint decline) {
+            final CheckpointCoordinator checkpointCoordinator =
+                    executionGraph.getCheckpointCoordinator();
+            final String taskManagerLocationInfo =
+                    retrieveTaskManagerLocation(executionGraph, decline.getTaskExecutionId());
+
+            if (checkpointCoordinator != null) {
+                ioExecutor.execute(
+                        () -> {
+                            try {
+                                checkpointCoordinator.receiveDeclineMessage(
+                                        decline, taskManagerLocationInfo);
+                            } catch (Exception e) {
+                                LOG.error(
+                                        "Error in CheckpointCoordinator while processing {}",
+                                        decline,
+                                        e);
+                            }
+                        });
+            } else {
+                String errorMessage =
+                        "Received DeclineCheckpoint message for job {} with no CheckpointCoordinator";
+                if (executionGraph.getState() == JobStatus.RUNNING) {
+                    LOG.error(errorMessage, jobGraph.getJobID());
+                } else {
+                    LOG.debug(errorMessage, jobGraph.getJobID());
+                }
+            }
+        }
+
+        public void updateAccumulators(AccumulatorSnapshot accumulatorSnapshot) {
+            executionGraph.updateAccumulators(accumulatorSnapshot);
+        }
+    }
+
+    // ----------------------------------------------------------------
+
+    interface ResourceConsumer {
+        void newResourcesAvailable();
+    }
+
+    interface State {
+        State cancel();
+
+        State suspend(Throwable cause);
+
+        JobStatus getJobStatus();
+
+        ArchivedExecutionGraph getJob();
+
+        default <T> Optional<T> as(Class<? extends T> clazz) {
+            if (clazz.isAssignableFrom(this.getClass())) {
+                return Optional.of(clazz.cast(this));
+            } else {
+                return Optional.empty();
+            }
+        }
+
+        default <T> void tryRun(Class<? extends T> clazz, Consumer<T> action, String debugMessage) {
+            OptionalConsumer.of(as(clazz))
+                    .ifPresent(action::accept)
+                    .ifNotPresent(
+                            () ->
+                                    LOG.debug(
+                                            "Cannot run '{}' because the actual state is {} and not {}.",
+                                            debugMessage,
+                                            this.getClass().getSimpleName(),
+                                            clazz.getSimpleName()));
+        }
+
+        default <T, V, E extends Exception> Optional<V> tryCall(
+                Class<? extends T> clazz,
+                FunctionWithException<T, V, E> action,
+                String debugMessage)
+                throws E {
+            final Optional<? extends T> asOptional = as(clazz);
+
+            if (asOptional.isPresent()) {
+                return Optional.of(action.apply(asOptional.get()));
+            } else {
+                LOG.debug(
+                        "Cannot run '{}' because the actual state is {} and not {}.",
+                        debugMessage,
+                        this.getClass().getSimpleName(),
+                        clazz.getSimpleName());
+                return Optional.empty();
+            }
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/ExecutionSlotSharingGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/ExecutionSlotSharingGroup.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * A parallel instance of a slot sharing group, containing exactly 1 subtask of some or all vertices
+ * belonging the same slot sharing group.
+ */
+class ExecutionSlotSharingGroup {
+    private final Set<ExecutionVertexID> containedExecutionVertices;
+
+    public ExecutionSlotSharingGroup(Set<ExecutionVertexID> containedExecutionVertices) {
+        this.containedExecutionVertices = containedExecutionVertices;
+    }
+
+    public Collection<ExecutionVertexID> getContainedExecutionVertices() {
+        return containedExecutionVertices;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/ExecutionSlotSharingGroupAndSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/ExecutionSlotSharingGroupAndSlot.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+
+/** An execution slot sharing group and the slot it could be assigned to. */
+public class ExecutionSlotSharingGroupAndSlot {
+    private final ExecutionSlotSharingGroup executionSlotSharingGroup;
+    private final SlotInfo slotInfo;
+
+    public ExecutionSlotSharingGroupAndSlot(
+            ExecutionSlotSharingGroup executionSlotSharingGroup, SlotInfo slotInfo) {
+        this.executionSlotSharingGroup = executionSlotSharingGroup;
+        this.slotInfo = slotInfo;
+    }
+
+    public ExecutionSlotSharingGroup getExecutionSlotSharingGroup() {
+        return executionSlotSharingGroup;
+    }
+
+    public SlotInfo getSlotInfo() {
+        return slotInfo;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/JobGraphJobInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/JobGraphJobInformation.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+
+import java.util.Collection;
+
+/** TODO: Add javadoc. */
+public class JobGraphJobInformation implements JobInformation {
+
+    private final JobGraph jobGraph;
+
+    public JobGraphJobInformation(JobGraph jobGraph) {
+        this.jobGraph = jobGraph;
+    }
+
+    @Override
+    public Collection<SlotSharingGroup> getSlotSharingGroups() {
+        return jobGraph.getSlotSharingGroups();
+    }
+
+    @Override
+    public VertexInformation getVertexInformation(JobVertexID jobVertexId) {
+        return new JobVertexInformation(jobGraph.findVertexByID(jobVertexId));
+    }
+
+    private static class JobVertexInformation implements VertexInformation {
+
+        private final JobVertex jobVertex;
+
+        private JobVertexInformation(JobVertex jobVertex) {
+            this.jobVertex = jobVertex;
+        }
+
+        @Override
+        public JobVertexID getJobVertexID() {
+            return jobVertex.getID();
+        }
+
+        @Override
+        public int getParallelism() {
+            return jobVertex.getParallelism();
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/JobInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/JobInformation.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+
+import java.util.Collection;
+
+/** Information about the job. */
+public interface JobInformation {
+    Collection<SlotSharingGroup> getSlotSharingGroups();
+
+    VertexInformation getVertexInformation(JobVertexID jobVertexId);
+
+    /** Information about a single vertex. */
+    interface VertexInformation {
+        JobVertexID getJobVertexID();
+
+        int getParallelism();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/MappingCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/MappingCalculator.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/** Calculates a potential mapping between slots & * vertices. */
+public interface MappingCalculator {
+
+    /**
+     * Attempts to create a mapping between vertices and slots.
+     *
+     * @param jobInformation information about the job graph
+     * @param freeSlots currently free slots
+     * @return mapping of slots and the vertices that should be deployed into them, if a mapping
+     *     could be found
+     */
+    Optional<SlotSharingAssignments> determineParallelismAndAssignResources(
+            JobInformation jobInformation, Collection<SlotInfoWithUtilization> freeSlots);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/RequirementsCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/RequirementsCalculator.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmaster.slotpool.ResourceCounter;
+
+/** Calculates resource requirements for a set of vertices. */
+public interface RequirementsCalculator {
+
+    /**
+     * Calculates the total resources required for scheduling the given vertices.
+     *
+     * @param vertices vertices to schedule
+     * @return required resources
+     */
+    // TODO: replace JobVertex with VertexInformation
+    ResourceCounter calculateRequiredSlots(Iterable<JobVertex> vertices);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/SharedSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/SharedSlot.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.jobmanager.scheduler.Locality;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotOwner;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlot;
+import org.apache.flink.runtime.jobmaster.slotpool.SingleLogicalSlot;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Shared slot implementation for the {@link DeclarativeScheduler}. */
+public class SharedSlot implements SlotOwner, PhysicalSlot.Payload {
+    private static final Logger LOG = LoggerFactory.getLogger(SharedSlot.class);
+
+    private final SlotRequestId physicalSlotRequestId;
+
+    private final PhysicalSlot physicalSlot;
+
+    private final Runnable externalReleaseCallback;
+
+    private final Map<SlotRequestId, LogicalSlot> allocatedLogicalSlots;
+
+    private final boolean slotWillBeOccupiedIndefinitely;
+
+    private State state;
+
+    public SharedSlot(
+            SlotRequestId physicalSlotRequestId,
+            PhysicalSlot physicalSlot,
+            boolean slotWillBeOccupiedIndefinitely,
+            Runnable externalReleaseCallback) {
+        this.physicalSlotRequestId = physicalSlotRequestId;
+        this.physicalSlot = physicalSlot;
+        this.slotWillBeOccupiedIndefinitely = slotWillBeOccupiedIndefinitely;
+        this.externalReleaseCallback = externalReleaseCallback;
+        this.state = State.ALLOCATED;
+        this.allocatedLogicalSlots = new HashMap<>();
+        physicalSlot.tryAssignPayload(this);
+    }
+
+    /**
+     * Registers an allocation request for a logical slot.
+     *
+     * <p>The logical slot request is complete once the underlying physical slot request is
+     * complete.
+     *
+     * @return the logical slot
+     */
+    public LogicalSlot allocateLogicalSlot() {
+        LOG.debug("Allocating logical slot from shared slot ({})", physicalSlotRequestId);
+        return new SingleLogicalSlot(
+                new SlotRequestId(),
+                physicalSlot,
+                null,
+                Locality.UNKNOWN,
+                this,
+                slotWillBeOccupiedIndefinitely);
+    }
+
+    @Override
+    public void returnLogicalSlot(LogicalSlot logicalSlot) {
+        LOG.debug("Returning logical slot to shared slot ({})", physicalSlotRequestId);
+        Preconditions.checkState(
+                allocatedLogicalSlots.remove(logicalSlot.getSlotRequestId()) != null,
+                "Trying to remove a logical slot request which has been either already removed or never created.");
+        tryReleaseExternally();
+    }
+
+    @Override
+    public void release(Throwable cause) {
+        LOG.debug("Release shared slot ({})", physicalSlotRequestId);
+
+        // copy the logical slot collection to avoid ConcurrentModificationException
+        // if logical slot releases cause cancellation of other executions
+        // which will try to call returnLogicalSlot and modify requestedLogicalSlots collection
+        final List<LogicalSlot> collect = new ArrayList<>(allocatedLogicalSlots.values());
+        for (LogicalSlot allocatedLogicalSlot : collect) {
+            allocatedLogicalSlot.releaseSlot(cause);
+        }
+        allocatedLogicalSlots.clear();
+        tryReleaseExternally();
+    }
+
+    private void tryReleaseExternally() {
+        if (state != State.RELEASED && allocatedLogicalSlots.isEmpty()) {
+            state = State.RELEASED;
+            LOG.debug("Release shared slot externally ({})", physicalSlotRequestId);
+            externalReleaseCallback.run();
+        }
+    }
+
+    @Override
+    public boolean willOccupySlotIndefinitely() {
+        return slotWillBeOccupiedIndefinitely;
+    }
+
+    private enum State {
+        ALLOCATED,
+        RELEASED
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/SlotSharingAssignments.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/SlotSharingAssignments.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** Mapping of slots to execution slot sharing groups. */
+public class SlotSharingAssignments {
+
+    private final Collection<ExecutionSlotSharingGroupAndSlot> assignments;
+
+    public SlotSharingAssignments(Collection<ExecutionSlotSharingGroupAndSlot> assignments) {
+        this.assignments = assignments;
+    }
+
+    public Iterable<ExecutionSlotSharingGroupAndSlot> getAssignments() {
+        return assignments;
+    }
+
+    public Map<JobVertexID, Integer> getMaxParallelismForVertices() {
+        return assignments.stream()
+                .map(ExecutionSlotSharingGroupAndSlot::getExecutionSlotSharingGroup)
+                .flatMap(x -> x.getContainedExecutionVertices().stream())
+                .collect(
+                        Collectors.toMap(
+                                ExecutionVertexID::getJobVertexId,
+                                v -> v.getSubtaskIndex() + 1,
+                                Math::max));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/SlotSharingMappingCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/SlotSharingMappingCalculator.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** {@link MappingCalculator} that supports slot sharing. */
+public class SlotSharingMappingCalculator implements MappingCalculator {
+
+    @Override
+    public Optional<SlotSharingAssignments> determineParallelismAndAssignResources(
+            JobInformation jobInformation, Collection<SlotInfoWithUtilization> freeSlots) {
+
+        // TODO: This can waste slots if the max parallelism for slot sharing groups is not equal
+        final int slotsPerSlotSharingGroup =
+                freeSlots.size() / jobInformation.getSlotSharingGroups().size();
+        final Iterator<SlotInfoWithUtilization> slotIterator = freeSlots.iterator();
+
+        final Collection<ExecutionSlotSharingGroupAndSlot> assignments = new ArrayList<>();
+
+        for (SlotSharingGroup slotSharingGroup : jobInformation.getSlotSharingGroups()) {
+            final List<JobInformation.VertexInformation> containedJobVertices =
+                    slotSharingGroup.getJobVertexIds().stream()
+                            .map(jobInformation::getVertexInformation)
+                            .collect(Collectors.toList());
+
+            final Iterable<ExecutionSlotSharingGroup> sharedSlotToVertexAssignment =
+                    determineParallelismAndAssignToFutureSlotIndex(
+                            containedJobVertices, slotsPerSlotSharingGroup);
+
+            for (ExecutionSlotSharingGroup executionSlotSharingGroup :
+                    sharedSlotToVertexAssignment) {
+                final SlotInfoWithUtilization slotInfo = slotIterator.next();
+
+                assignments.add(
+                        new ExecutionSlotSharingGroupAndSlot(executionSlotSharingGroup, slotInfo));
+            }
+        }
+
+        return Optional.of(new SlotSharingAssignments(assignments));
+    }
+
+    private Iterable<ExecutionSlotSharingGroup> determineParallelismAndAssignToFutureSlotIndex(
+            Collection<JobInformation.VertexInformation> containedJobVertices, int availableSlots) {
+        final Map<Integer, Set<ExecutionVertexID>> sharedSlotToVertexAssignment = new HashMap<>();
+        for (JobInformation.VertexInformation jobVertex : containedJobVertices) {
+            final int parallelism = Math.min(jobVertex.getParallelism(), availableSlots);
+
+            for (int i = 0; i < parallelism; i++) {
+                sharedSlotToVertexAssignment
+                        .computeIfAbsent(i, ignored -> new HashSet<>())
+                        .add(new ExecutionVertexID(jobVertex.getJobVertexID(), i));
+            }
+        }
+
+        return sharedSlotToVertexAssignment.values().stream()
+                .map(ExecutionSlotSharingGroup::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/SlotSharingRequirementsCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/SlotSharingRequirementsCalculator.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmaster.slotpool.ResourceCounter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** {@link RequirementsCalculator} that supports slot sharing. */
+public class SlotSharingRequirementsCalculator implements RequirementsCalculator {
+
+    @Override
+    public ResourceCounter calculateRequiredSlots(Iterable<JobVertex> vertices) {
+        int numTotalRequiredSlots = 0;
+        for (Integer requiredSlots : getMaxParallelismForSlotSharingGroups(vertices).values()) {
+            numTotalRequiredSlots += requiredSlots;
+        }
+        return ResourceCounter.withResource(ResourceProfile.UNKNOWN, numTotalRequiredSlots);
+    }
+
+    private static Map<SlotSharingGroupId, Integer> getMaxParallelismForSlotSharingGroups(
+            Iterable<JobVertex> vertices) {
+        final Map<SlotSharingGroupId, Integer> maxParallelismForSlotSharingGroups = new HashMap<>();
+        for (JobVertex vertex : vertices) {
+            maxParallelismForSlotSharingGroups.compute(
+                    vertex.getSlotSharingGroup().getSlotSharingGroupId(),
+                    (slotSharingGroupId, currentMaxParallelism) ->
+                            currentMaxParallelism == null
+                                    ? vertex.getParallelism()
+                                    : Math.max(currentMaxParallelism, vertex.getParallelism()));
+        }
+        return maxParallelismForSlotSharingGroups;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/SchedulerNGFactoryFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/SchedulerNGFactoryFactoryTest.java
@@ -44,7 +44,7 @@ public class SchedulerNGFactoryFactoryTest extends TestLogger {
     @Test
     public void createSchedulerNGFactoryIfConfigured() {
         final Configuration configuration = new Configuration();
-        configuration.setString(JobManagerOptions.SCHEDULER, "ng");
+        configuration.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Ng);
 
         final SchedulerNGFactory schedulerNGFactory = createSchedulerNGFactory(configuration);
 
@@ -54,12 +54,14 @@ public class SchedulerNGFactoryFactoryTest extends TestLogger {
     @Test
     public void throwsExceptionIfSchedulerNameIsInvalid() {
         final Configuration configuration = new Configuration();
-        configuration.setString(JobManagerOptions.SCHEDULER, "invalid-scheduler-name");
+        configuration.setString(JobManagerOptions.SCHEDULER.key(), "invalid-scheduler-name");
 
         try {
             createSchedulerNGFactory(configuration);
         } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString("Illegal value [invalid-scheduler-name]"));
+            assertThat(
+                    e.getMessage(),
+                    containsString("Could not parse value 'invalid-scheduler-name'"));
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterSchedulerTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolService;
 import org.apache.flink.runtime.jobmaster.utils.JobMasterBuilder;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
@@ -90,7 +90,7 @@ public class JobMasterSchedulerTest extends TestLogger {
                 BackPressureStatsTracker backPressureStatsTracker,
                 Executor ioExecutor,
                 Configuration jobMasterConfiguration,
-                SlotPool slotPool,
+                SlotPoolService slotPoolService,
                 ScheduledExecutorService futureExecutor,
                 ClassLoader userCodeLoader,
                 CheckpointRecoveryFactory checkpointRecoveryFactory,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
@@ -39,7 +39,7 @@ import org.apache.flink.runtime.jobmaster.JobMasterConfiguration;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.TestingJobManagerSharedServicesBuilder;
 import org.apache.flink.runtime.jobmaster.factories.UnregisteredJobManagerJobMetricGroupFactory;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolServiceFactory;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -73,7 +73,7 @@ public class JobMasterBuilder {
 
     private HeartbeatServices heartbeatServices = DEFAULT_HEARTBEAT_SERVICES;
 
-    private SlotPoolFactory slotPoolFactory = null;
+    private SlotPoolServiceFactory slotPoolFactory = null;
 
     private OnCompletionActions onCompletionActions = new TestingOnCompletionActions();
 
@@ -129,7 +129,7 @@ public class JobMasterBuilder {
         return this;
     }
 
-    public JobMasterBuilder withSlotPoolFactory(SlotPoolFactory slotPoolFactory) {
+    public JobMasterBuilder withSlotPoolFactory(SlotPoolServiceFactory slotPoolFactory) {
         this.slotPoolFactory = slotPoolFactory;
         return this;
     }
@@ -195,7 +195,7 @@ public class JobMasterBuilder {
                 highAvailabilityServices,
                 slotPoolFactory != null
                         ? slotPoolFactory
-                        : SlotPoolFactory.fromConfiguration(configuration),
+                        : SlotPoolServiceFactory.fromConfiguration(configuration),
                 jobManagerSharedServices,
                 heartbeatServices,
                 UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNGFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNGFactory.java
@@ -25,7 +25,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolService;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
@@ -53,7 +53,7 @@ public class TestingSchedulerNGFactory implements SchedulerNGFactory {
             BackPressureStatsTracker backPressureStatsTracker,
             Executor ioExecutor,
             Configuration jobMasterConfiguration,
-            SlotPool slotPool,
+            SlotPoolService slotPoolService,
             ScheduledExecutorService futureExecutor,
             ClassLoader userCodeLoader,
             CheckpointRecoveryFactory checkpointRecoveryFactory,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerClusterITCase.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.dispatcher.SchedulerNGFactoryFactory;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.testtasks.OnceBlockingNoOpInvokable;
+import org.apache.flink.runtime.testutils.MiniClusterResource;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * This class contains integration tests for the declarative scheduler which start a {@link
+ * org.apache.flink.runtime.minicluster.MiniCluster} per test case.
+ */
+public class DeclarativeSchedulerClusterITCase extends TestLogger {
+
+    private static final int NUMBER_SLOTS_PER_TASK_MANAGER = 2;
+    private static final int NUMBER_TASK_MANAGERS = 2;
+    private static final int PARALLELISM = NUMBER_SLOTS_PER_TASK_MANAGER * NUMBER_TASK_MANAGERS;
+
+    @Rule
+    public final MiniClusterResource miniClusterResource =
+            new MiniClusterResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setConfiguration(createConfiguration())
+                            .setNumberSlotsPerTaskManager(NUMBER_SLOTS_PER_TASK_MANAGER)
+                            .setNumberTaskManagers(NUMBER_TASK_MANAGERS)
+                            .build());
+
+    private Configuration createConfiguration() {
+        final Configuration configuration = new Configuration();
+
+        configuration.set(
+                JobManagerOptions.SCHEDULER, SchedulerNGFactoryFactory.DECLARATIVE_SCHEDULER);
+        configuration.set(ClusterOptions.ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT, true);
+
+        return configuration;
+    }
+
+    @Test
+    public void testAutomaticScaleDownInCaseOfLostSlots() throws InterruptedException {
+        final MiniCluster miniCluster = miniClusterResource.getMiniCluster();
+        final JobGraph jobGraph = createBlockingJobGraph(PARALLELISM);
+
+        miniCluster.submitJob(jobGraph).join();
+        final CompletableFuture<JobResult> resultFuture =
+                miniCluster.requestJobResult(jobGraph.getJobID());
+
+        OnceBlockingNoOpInvokable.waitUntilOpsAreRunning();
+
+        miniCluster.terminateTaskManager(0);
+
+        final JobResult jobResult = resultFuture.join();
+
+        assertTrue(jobResult.isSuccess());
+    }
+
+    private JobGraph createBlockingJobGraph(int parallelism) {
+        final JobVertex blockingOperator = new JobVertex("Blocking operator");
+
+        OnceBlockingNoOpInvokable.resetFor(parallelism);
+        blockingOperator.setInvokableClass(OnceBlockingNoOpInvokable.class);
+
+        blockingOperator.setParallelism(parallelism);
+
+        final JobGraph jobGraph = new JobGraph("Blocking job.", blockingOperator);
+
+        return jobGraph;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerClusterITCase.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import java.util.concurrent.CompletableFuture;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * This class contains integration tests for the declarative scheduler which start a {@link
@@ -48,11 +49,13 @@ public class DeclarativeSchedulerClusterITCase extends TestLogger {
     private static final int NUMBER_TASK_MANAGERS = 2;
     private static final int PARALLELISM = NUMBER_SLOTS_PER_TASK_MANAGER * NUMBER_TASK_MANAGERS;
 
+    private final Configuration configuration = createConfiguration();
+
     @Rule
     public final MiniClusterResource miniClusterResource =
             new MiniClusterResource(
                     new MiniClusterResourceConfiguration.Builder()
-                            .setConfiguration(createConfiguration())
+                            .setConfiguration(configuration)
                             .setNumberSlotsPerTaskManager(NUMBER_SLOTS_PER_TASK_MANAGER)
                             .setNumberTaskManagers(NUMBER_TASK_MANAGERS)
                             .build());
@@ -69,6 +72,8 @@ public class DeclarativeSchedulerClusterITCase extends TestLogger {
 
     @Test
     public void testAutomaticScaleDownInCaseOfLostSlots() throws InterruptedException {
+        assumeTrue(ClusterOptions.isDeclarativeResourceManagementEnabled(configuration));
+
         final MiniCluster miniCluster = miniClusterResource.getMiniCluster();
         final JobGraph jobGraph = createBlockingJobGraph(PARALLELISM);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerClusterITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.scheduler.declarative;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
-import org.apache.flink.runtime.dispatcher.SchedulerNGFactoryFactory;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmaster.JobResult;
@@ -63,8 +62,7 @@ public class DeclarativeSchedulerClusterITCase extends TestLogger {
     private Configuration createConfiguration() {
         final Configuration configuration = new Configuration();
 
-        configuration.set(
-                JobManagerOptions.SCHEDULER, SchedulerNGFactoryFactory.DECLARATIVE_SCHEDULER);
+        configuration.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Declarative);
         configuration.set(ClusterOptions.ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT, true);
 
         return configuration;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerClusterITCase.java
@@ -28,10 +28,12 @@ import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.testtasks.OnceBlockingNoOpInvokable;
 import org.apache.flink.runtime.testutils.MiniClusterResource;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.testutils.junit.WithDeclarativeScheduler;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -42,6 +44,7 @@ import static org.junit.Assume.assumeTrue;
  * This class contains integration tests for the declarative scheduler which start a {@link
  * org.apache.flink.runtime.minicluster.MiniCluster} per test case.
  */
+@Category(WithDeclarativeScheduler.class)
 public class DeclarativeSchedulerClusterITCase extends TestLogger {
 
     private static final int NUMBER_SLOTS_PER_TASK_MANAGER = 2;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerITCase.java
@@ -44,6 +44,7 @@ public class DeclarativeSchedulerITCase extends TestLogger {
 
     private static final int NUMBER_TASK_MANAGERS = 2;
     private static final int NUMBER_SLOTS_PER_TASK_MANAGER = 2;
+    private static final int PARALLELISM = 10;
 
     private static Configuration getConfiguration() {
         final Configuration configuration = new Configuration();
@@ -82,11 +83,11 @@ public class DeclarativeSchedulerITCase extends TestLogger {
     private JobGraph createJobGraph() {
         final JobVertex source = new JobVertex("Source");
         source.setInvokableClass(NoOpInvokable.class);
-        source.setParallelism(NUMBER_SLOTS_PER_TASK_MANAGER);
+        source.setParallelism(PARALLELISM);
 
         final JobVertex sink = new JobVertex("sink");
         sink.setInvokableClass(NoOpInvokable.class);
-        sink.setParallelism(NUMBER_SLOTS_PER_TASK_MANAGER);
+        sink.setParallelism(PARALLELISM);
 
         sink.connectNewDataSetAsInput(
                 source, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerITCase.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.dispatcher.SchedulerNGFactoryFactory;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.runtime.testutils.MiniClusterResource;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/** Integration tests for the {@link DeclarativeScheduler}. */
+public class DeclarativeSchedulerITCase extends TestLogger {
+
+    private static final int NUMBER_TASK_MANAGERS = 2;
+    private static final int NUMBER_SLOTS_PER_TASK_MANAGER = 2;
+
+    private static Configuration getConfiguration() {
+        final Configuration configuration = new Configuration();
+
+        configuration.set(
+                JobManagerOptions.SCHEDULER, SchedulerNGFactoryFactory.DECLARATIVE_SCHEDULER);
+        configuration.set(ClusterOptions.ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT, true);
+
+        return configuration;
+    }
+
+    @ClassRule
+    public static final MiniClusterResource MINI_CLUSTER_RESOURCE =
+            new MiniClusterResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setConfiguration(getConfiguration())
+                            .setNumberTaskManagers(NUMBER_TASK_MANAGERS)
+                            .setNumberSlotsPerTaskManager(NUMBER_SLOTS_PER_TASK_MANAGER)
+                            .build());
+
+    @Test
+    public void testSchedulingOfSimpleJob() throws Exception {
+        final MiniCluster miniCluster = MINI_CLUSTER_RESOURCE.getMiniCluster();
+        final JobGraph jobGraph = createJobGraph();
+
+        miniCluster.submitJob(jobGraph).join();
+
+        final JobResult jobResult = miniCluster.requestJobResult(jobGraph.getJobID()).join();
+
+        final JobExecutionResult jobExecutionResult =
+                jobResult.toJobExecutionResult(getClass().getClassLoader());
+
+        assertTrue(jobResult.isSuccess());
+    }
+
+    private JobGraph createJobGraph() {
+        final JobVertex source = new JobVertex("Source");
+        source.setInvokableClass(NoOpInvokable.class);
+        source.setParallelism(NUMBER_SLOTS_PER_TASK_MANAGER);
+
+        final JobVertex sink = new JobVertex("sink");
+        sink.setInvokableClass(NoOpInvokable.class);
+        sink.setParallelism(NUMBER_SLOTS_PER_TASK_MANAGER);
+
+        sink.connectNewDataSetAsInput(
+                source, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
+
+        return new JobGraph("Simple job", source, sink);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerITCase.java
@@ -116,7 +116,7 @@ public class DeclarativeSchedulerITCase extends TestLogger {
         OnceFailingInvokable.reset();
         onceFailingOperator.setInvokableClass(OnceFailingInvokable.class);
 
-        onceFailingOperator.setParallelism(2);
+        onceFailingOperator.setParallelism(1);
         final JobGraph jobGraph = new JobGraph("Once failing job", onceFailingOperator);
         return jobGraph;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerITCase.java
@@ -35,7 +35,6 @@ import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
@@ -65,7 +64,6 @@ public class DeclarativeSchedulerITCase extends TestLogger {
                             .setNumberSlotsPerTaskManager(NUMBER_SLOTS_PER_TASK_MANAGER)
                             .build());
 
-	@Ignore
     @Test
     public void testSchedulingOfSimpleJob() throws Exception {
         final MiniCluster miniCluster = MINI_CLUSTER_RESOURCE.getMiniCluster();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerITCase.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
@@ -64,6 +65,7 @@ public class DeclarativeSchedulerITCase extends TestLogger {
                             .setNumberSlotsPerTaskManager(NUMBER_SLOTS_PER_TASK_MANAGER)
                             .build());
 
+	@Ignore
     @Test
     public void testSchedulingOfSimpleJob() throws Exception {
         final MiniCluster miniCluster = MINI_CLUSTER_RESOURCE.getMiniCluster();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSimpleITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSimpleITCase.java
@@ -33,16 +33,19 @@ import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.MiniClusterResource;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.testutils.junit.WithDeclarativeScheduler;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 /** Integration tests for the {@link DeclarativeScheduler}. */
+@Category(WithDeclarativeScheduler.class)
 public class DeclarativeSchedulerSimpleITCase extends TestLogger {
 
     private static final int NUMBER_TASK_MANAGERS = 2;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSimpleITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSimpleITCase.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
-import org.apache.flink.runtime.dispatcher.SchedulerNGFactoryFactory;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
@@ -55,8 +54,7 @@ public class DeclarativeSchedulerSimpleITCase extends TestLogger {
     private static Configuration getConfiguration() {
         final Configuration configuration = new Configuration();
 
-        configuration.set(
-                JobManagerOptions.SCHEDULER, SchedulerNGFactoryFactory.DECLARATIVE_SCHEDULER);
+        configuration.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Declarative);
         configuration.set(ClusterOptions.ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT, true);
 
         return configuration;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSimpleITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSimpleITCase.java
@@ -43,7 +43,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertTrue;
 
 /** Integration tests for the {@link DeclarativeScheduler}. */
-public class DeclarativeSchedulerITCase extends TestLogger {
+public class DeclarativeSchedulerSimpleITCase extends TestLogger {
 
     private static final int NUMBER_TASK_MANAGERS = 2;
     private static final int NUMBER_SLOTS_PER_TASK_MANAGER = 2;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSimpleITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSimpleITCase.java
@@ -41,6 +41,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 /** Integration tests for the {@link DeclarativeScheduler}. */
 public class DeclarativeSchedulerSimpleITCase extends TestLogger {
@@ -48,6 +49,8 @@ public class DeclarativeSchedulerSimpleITCase extends TestLogger {
     private static final int NUMBER_TASK_MANAGERS = 2;
     private static final int NUMBER_SLOTS_PER_TASK_MANAGER = 2;
     private static final int PARALLELISM = 10;
+
+    private static final Configuration configuration = getConfiguration();
 
     private static Configuration getConfiguration() {
         final Configuration configuration = new Configuration();
@@ -63,13 +66,15 @@ public class DeclarativeSchedulerSimpleITCase extends TestLogger {
     public static final MiniClusterResource MINI_CLUSTER_RESOURCE =
             new MiniClusterResource(
                     new MiniClusterResourceConfiguration.Builder()
-                            .setConfiguration(getConfiguration())
+                            .setConfiguration(configuration)
                             .setNumberTaskManagers(NUMBER_TASK_MANAGERS)
                             .setNumberSlotsPerTaskManager(NUMBER_SLOTS_PER_TASK_MANAGER)
                             .build());
 
     @Test
     public void testSchedulingOfSimpleJob() throws Exception {
+        assumeTrue(ClusterOptions.isDeclarativeResourceManagementEnabled(configuration));
+
         final MiniCluster miniCluster = MINI_CLUSTER_RESOURCE.getMiniCluster();
         final JobGraph jobGraph = createJobGraph();
 
@@ -100,6 +105,8 @@ public class DeclarativeSchedulerSimpleITCase extends TestLogger {
 
     @Test
     public void testGlobalFailoverIfTaskFails() {
+        assumeTrue(ClusterOptions.isDeclarativeResourceManagementEnabled(configuration));
+
         final MiniCluster miniCluster = MINI_CLUSTER_RESOURCE.getMiniCluster();
         final JobGraph jobGraph = createOnceFailingJobGraph();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSlotSharingITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSlotSharingITCase.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.dispatcher.SchedulerNGFactoryFactory;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.runtime.testutils.MiniClusterResource;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/** SlotSharing tests for the {@link DeclarativeScheduler}. */
+public class DeclarativeSchedulerSlotSharingITCase extends TestLogger {
+
+    private static final int NUMBER_TASK_MANAGERS = 1;
+    private static final int NUMBER_SLOTS_PER_TASK_MANAGER = 1;
+    private static final int PARALLELISM = 10;
+
+    private static Configuration getConfiguration() {
+        final Configuration configuration = new Configuration();
+
+        configuration.set(
+                JobManagerOptions.SCHEDULER, SchedulerNGFactoryFactory.DECLARATIVE_SCHEDULER);
+        configuration.set(
+                JobManagerOptions.DECLARATIVE_SCHEDULER_TYPE,
+                JobManagerOptions.DeclarativeSchedulerType.Old);
+        configuration.set(ClusterOptions.ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT, true);
+
+        return configuration;
+    }
+
+    @ClassRule
+    public static final MiniClusterResource MINI_CLUSTER_RESOURCE =
+            new MiniClusterResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setConfiguration(getConfiguration())
+                            .setNumberTaskManagers(NUMBER_TASK_MANAGERS)
+                            .setNumberSlotsPerTaskManager(NUMBER_SLOTS_PER_TASK_MANAGER)
+                            .build());
+
+    @Test
+    public void testSchedulingOfJobRequiringSlotSharing() throws Exception {
+        // run job multiple times to ensure slots are cleaned up properly
+        runJob();
+        runJob();
+    }
+
+    private void runJob() throws Exception {
+        final MiniCluster miniCluster = MINI_CLUSTER_RESOURCE.getMiniCluster();
+        final JobGraph jobGraph = createJobGraph();
+
+        miniCluster.submitJob(jobGraph).join();
+
+        final JobResult jobResult = miniCluster.requestJobResult(jobGraph.getJobID()).join();
+
+        // this throws an exception if the job failed
+        jobResult.toJobExecutionResult(getClass().getClassLoader());
+
+        assertTrue(jobResult.isSuccess());
+    }
+
+    /**
+     * Returns a JobGraph that requires slot sharing to work in order to be able to run with a
+     * single slot.
+     */
+    private static JobGraph createJobGraph() {
+        final SlotSharingGroup slotSharingGroup = new SlotSharingGroup();
+
+        final JobVertex source = new JobVertex("Source");
+        source.setInvokableClass(NoOpInvokable.class);
+        source.setParallelism(PARALLELISM);
+        source.setSlotSharingGroup(slotSharingGroup);
+
+        final JobVertex sink = new JobVertex("sink");
+        sink.setInvokableClass(NoOpInvokable.class);
+        sink.setParallelism(PARALLELISM);
+        sink.setSlotSharingGroup(slotSharingGroup);
+
+        sink.connectNewDataSetAsInput(
+                source, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
+
+        return new JobGraph("Simple job", source, sink);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSlotSharingITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSlotSharingITCase.java
@@ -31,14 +31,17 @@ import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.MiniClusterResource;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.testutils.junit.WithDeclarativeScheduler;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertTrue;
 
 /** SlotSharing tests for the {@link DeclarativeScheduler}. */
+@Category(WithDeclarativeScheduler.class)
 public class DeclarativeSchedulerSlotSharingITCase extends TestLogger {
 
     private static final int NUMBER_TASK_MANAGERS = 1;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSlotSharingITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSlotSharingITCase.java
@@ -53,7 +53,7 @@ public class DeclarativeSchedulerSlotSharingITCase extends TestLogger {
                 JobManagerOptions.SCHEDULER, SchedulerNGFactoryFactory.DECLARATIVE_SCHEDULER);
         configuration.set(
                 JobManagerOptions.DECLARATIVE_SCHEDULER_TYPE,
-                JobManagerOptions.DeclarativeSchedulerType.Old);
+                JobManagerOptions.DeclarativeSchedulerType.StateMachine);
         configuration.set(ClusterOptions.ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT, true);
 
         return configuration;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSlotSharingITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerSlotSharingITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.scheduler.declarative;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
-import org.apache.flink.runtime.dispatcher.SchedulerNGFactoryFactory;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -49,8 +48,7 @@ public class DeclarativeSchedulerSlotSharingITCase extends TestLogger {
     private static Configuration getConfiguration() {
         final Configuration configuration = new Configuration();
 
-        configuration.set(
-                JobManagerOptions.SCHEDULER, SchedulerNGFactoryFactory.DECLARATIVE_SCHEDULER);
+        configuration.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Declarative);
         configuration.set(
                 JobManagerOptions.DECLARATIVE_SCHEDULER_TYPE,
                 JobManagerOptions.DeclarativeSchedulerType.StateMachine);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testtasks/UnblockNoOpInvokable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testtasks/UnblockNoOpInvokable.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.testtasks;
+
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Simple {@link AbstractInvokable} which blocks until the user calls {@link #unblock()}. Moreover,
+ * one can wait until n instances of this invokable are running by calling {@link
+ * #waitUntilOpsAreRunning()}.
+ *
+ * <p>Before using this class it is important to call {@link #resetFor}.
+ */
+public class UnblockNoOpInvokable extends AbstractInvokable {
+
+    private static volatile OneShotLatch blockingLatch = new OneShotLatch();
+    private static volatile CountDownLatch numOpsRunning = new CountDownLatch(1);
+
+    public UnblockNoOpInvokable(Environment environment) {
+        super(environment);
+    }
+
+    @Override
+    public void invoke() throws Exception {
+        numOpsRunning.countDown();
+        blockingLatch.await();
+    }
+
+    public static void unblock() {
+        blockingLatch.trigger();
+    }
+
+    public static void waitUntilOpsAreRunning() throws InterruptedException {
+        numOpsRunning.await();
+    }
+
+    public static void resetFor(int parallelism) {
+        numOpsRunning = new CountDownLatch(parallelism);
+        blockingLatch = new OneShotLatch();
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/WithDeclarativeScheduler.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/WithDeclarativeScheduler.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.testutils.junit;
+
+/** Marker interface for tests that can run with the declarative scheduler. */
+public interface WithDeclarativeScheduler {}

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/DeclarativeSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/DeclarativeSchedulerITCase.java
@@ -45,12 +45,16 @@ import org.junit.Test;
 
 import javax.annotation.Nullable;
 
+import static org.junit.Assume.assumeTrue;
+
 /** Integration tests for the {@link DeclarativeScheduler}. */
 public class DeclarativeSchedulerITCase extends TestLogger {
 
     private static final int NUMBER_TASK_MANAGERS = 2;
     private static final int NUMBER_SLOTS_PER_TASK_MANAGER = 2;
     private static final int PARALLELISM = NUMBER_SLOTS_PER_TASK_MANAGER * NUMBER_TASK_MANAGERS;
+
+    private static final Configuration configuration = getConfiguration();
 
     private static Configuration getConfiguration() {
         final Configuration configuration = new Configuration();
@@ -74,6 +78,7 @@ public class DeclarativeSchedulerITCase extends TestLogger {
     /** Tests that the declarative scheduler can recover stateful operators. */
     @Test
     public void testGlobalFailoverCanRecoverState() throws Exception {
+        assumeTrue(ClusterOptions.isDeclarativeResourceManagementEnabled(configuration));
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(PARALLELISM);

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/DeclarativeSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/DeclarativeSchedulerITCase.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.scheduling;
+
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.dispatcher.SchedulerNGFactoryFactory;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.runtime.testutils.MiniClusterResource;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+public class DeclarativeSchedulerITCase extends TestLogger {
+
+    private static final int NUMBER_TASK_MANAGERS = 2;
+    private static final int NUMBER_SLOTS_PER_TASK_MANAGER = 2;
+    private static final int PARALLELISM = NUMBER_SLOTS_PER_TASK_MANAGER * NUMBER_TASK_MANAGERS;
+
+    private static Configuration getConfiguration() {
+        final Configuration configuration = new Configuration();
+
+        configuration.set(
+                JobManagerOptions.SCHEDULER, SchedulerNGFactoryFactory.DECLARATIVE_SCHEDULER);
+        configuration.set(ClusterOptions.ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT, true);
+
+        return configuration;
+    }
+
+    @ClassRule
+    public static final MiniClusterResource MINI_CLUSTER_WITH_CLIENT_RESOURCE =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setConfiguration(getConfiguration())
+                            .setNumberTaskManagers(NUMBER_TASK_MANAGERS)
+                            .setNumberSlotsPerTaskManager(NUMBER_SLOTS_PER_TASK_MANAGER)
+                            .build());
+
+    /** Tests that the declarative scheduler can recover stateful operators. */
+    @Ignore
+    @Test
+    public void testGlobalFailoverCanRecoverState() throws Exception {
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(PARALLELISM);
+
+        env.enableCheckpointing(20L, CheckpointingMode.EXACTLY_ONCE);
+        final DataStreamSource<Integer> input = env.addSource(new SimpleSource());
+
+        input.addSink(new DiscardingSink<>());
+
+        env.execute();
+    }
+
+    public static final class SimpleSource extends RichParallelSourceFunction<Integer>
+            implements CheckpointListener, CheckpointedFunction {
+
+        private static final ListStateDescriptor<Boolean> unionStateListDescriptor =
+                new ListStateDescriptor<>("state", Boolean.class);
+
+        private volatile boolean running = true;
+
+        @Nullable private ListState<Boolean> unionListState = null;
+
+        private boolean hasFailedBefore = false;
+
+        private boolean fail = false;
+
+        @Override
+        public void run(SourceContext<Integer> ctx) throws Exception {
+            while (running && !hasFailedBefore) {
+                synchronized (ctx.getCheckpointLock()) {
+                    ctx.collect(getRuntimeContext().getIndexOfThisSubtask());
+
+                    Thread.sleep(5L);
+                }
+
+                if (fail) {
+                    throw new FlinkException("Test failure.");
+                }
+            }
+        }
+
+        @Override
+        public void cancel() {
+            running = false;
+        }
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) throws Exception {
+            fail = true;
+        }
+
+        @Override
+        public void snapshotState(FunctionSnapshotContext context) throws Exception {}
+
+        @Override
+        public void initializeState(FunctionInitializationContext context) throws Exception {
+            unionListState =
+                    context.getOperatorStateStore().getUnionListState(unionStateListDescriptor);
+
+            for (Boolean previousState : unionListState.get()) {
+                hasFailedBefore |= previousState;
+            }
+
+            unionListState.clear();
+            unionListState.add(true);
+        }
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/DeclarativeSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/DeclarativeSchedulerITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.dispatcher.SchedulerNGFactoryFactory;
+import org.apache.flink.runtime.scheduler.declarative.DeclarativeScheduler;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.runtime.testutils.MiniClusterResource;
@@ -44,6 +45,7 @@ import org.junit.Test;
 
 import javax.annotation.Nullable;
 
+/** Integration tests for the {@link DeclarativeScheduler}. */
 public class DeclarativeSchedulerITCase extends TestLogger {
 
     private static final int NUMBER_TASK_MANAGERS = 2;
@@ -84,6 +86,10 @@ public class DeclarativeSchedulerITCase extends TestLogger {
         env.execute();
     }
 
+    /**
+     * Simple source which fails once after a successful checkpoint has been taken. Upon recovery
+     * the source will immediately terminate.
+     */
     public static final class SimpleSource extends RichParallelSourceFunction<Integer>
             implements CheckpointListener, CheckpointedFunction {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/DeclarativeSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/DeclarativeSchedulerITCase.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
-import org.apache.flink.runtime.dispatcher.SchedulerNGFactoryFactory;
 import org.apache.flink.runtime.scheduler.declarative.DeclarativeScheduler;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -59,8 +58,7 @@ public class DeclarativeSchedulerITCase extends TestLogger {
     private static Configuration getConfiguration() {
         final Configuration configuration = new Configuration();
 
-        configuration.set(
-                JobManagerOptions.SCHEDULER, SchedulerNGFactoryFactory.DECLARATIVE_SCHEDULER);
+        configuration.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Declarative);
         configuration.set(ClusterOptions.ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT, true);
 
         return configuration;

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/DeclarativeSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/DeclarativeSchedulerITCase.java
@@ -40,7 +40,6 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
@@ -71,7 +70,6 @@ public class DeclarativeSchedulerITCase extends TestLogger {
                             .build());
 
     /** Tests that the declarative scheduler can recover stateful operators. */
-    @Ignore
     @Test
     public void testGlobalFailoverCanRecoverState() throws Exception {
 

--- a/pom.xml
+++ b/pom.xml
@@ -1320,6 +1320,62 @@ under the License.
 				</pluginManagement>
 			</build>
 		</profile>
+
+		<profile>
+			<id>with-declarative-scheduler</id>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-surefire-plugin</artifactId>
+							<configuration>
+								<groups>org.apache.flink.testutils.junit.WithDeclarativeScheduler</groups>
+							</configuration>
+						</plugin>
+
+						<plugin>
+							<groupId>org.codehaus.gmavenplus</groupId>
+							<artifactId>gmavenplus-plugin</artifactId>
+							<version>1.8.1</version>
+							<dependencies>
+								<dependency>
+									<groupId>org.codehaus.groovy</groupId>
+									<artifactId>groovy-all</artifactId>
+									<version>2.5.12</version>
+									<scope>runtime</scope>
+									<type>pom</type>
+								</dependency>
+							</dependencies>
+							<executions>
+								<execution>
+									<id>enable-declarative</id>
+									<phase>initialize</phase>
+									<goals>
+										<goal>execute</goal>
+									</goals>
+									<configuration>
+										<scripts>
+											<script>
+												<![CDATA[
+												System.properties['flink.tests.enable-declarative-scheduler'] = true
+												]]>
+											</script>
+										</scripts>
+									</configuration>
+								</execution>
+							</executions>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.gmavenplus</groupId>
+						<artifactId>gmavenplus-plugin</artifactId>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 
 	<build>

--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -105,6 +105,8 @@ jobs:
         module: misc
       legacy_slot_management:
         module: legacy_slot_management
+      declarative_scheduler:
+        module: declarative_scheduler
   steps:
   # if on Azure, free up disk space
   - script: ./tools/azure-pipelines/free_disk_space.sh

--- a/tools/ci/stage.sh
+++ b/tools/ci/stage.sh
@@ -28,6 +28,7 @@ STAGE_TESTS="tests"
 STAGE_MISC="misc"
 STAGE_CLEANUP="cleanup"
 STAGE_LEGACY_SLOT_MANAGEMENT="legacy_slot_management"
+STAGE_DECLARATIVE_SCHEDULER="declarative_scheduler"
 
 MODULES_CORE="\
 flink-annotations,\
@@ -164,6 +165,9 @@ function get_compile_modules_for_stage() {
         (${STAGE_LEGACY_SLOT_MANAGEMENT})
             echo "-pl $MODULES_LEGACY_SLOT_MANAGEMENT -am"
         ;;
+        (${STAGE_DECLARATIVE_SCHEDULER})
+            echo "-pl $MODULES_LEGACY_SLOT_MANAGEMENT -am"
+        ;;
     esac
 }
 
@@ -208,6 +212,9 @@ function get_test_modules_for_stage() {
         ;;
         (${STAGE_LEGACY_SLOT_MANAGEMENT})
             echo "-pl $modules_legacy_slot_management"
+        ;;
+        (${STAGE_DECLARATIVE_SCHEDULER})
+            echo "-pl $modules_legacy_slot_management -am -Pwith-declarative-scheduler"
         ::
     esac
 }


### PR DESCRIPTION
Sets up a CI profile that enables the `with-declarative-scheduler` maven profile, which enables the declarative scheduler and resource management through a system property and runs tests with the `WithDeclarativeScheduler` category.

For local testing the `flink.tests.enable-declarative-scheduler` property can be set to run all tests with the declarative scheduler (unless they specifically configure the Ng scheduler).