### PR TITLE
Restructure SlotAllocator interface

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/SlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/SlotAllocator.java
@@ -24,17 +24,29 @@ import java.util.Collection;
 import java.util.Optional;
 
 /** Component for calculating the slot requirements and mapping of vertices to slots. */
-public interface SlotAllocator extends RequirementsCalculator {
+public interface SlotAllocator<T extends VertexAssignment> extends RequirementsCalculator {
 
     /**
-     * Attempts to create a mapping between vertices and slots.
+     * Determines the parallelism at which the vertices could given the collection of slots.
      *
      * @param jobInformation information about the job graph
      * @param freeSlots currently free slots
-     * @return parallelism of each vertex and mapping slots to vertices, if a mapping could be
-     *     computed
+     * @return parallelism of each vertex along with implementation specific information, if the job
+     *     could be run with the given slots
      */
-    Optional<DeclarativeScheduler.ParallelismAndResourceAssignments>
-            determineParallelismAndAssignResources(
-                    JobInformation jobInformation, Collection<SlotInfoWithUtilization> freeSlots);
+    Optional<T> determineParallelism(
+            JobInformation jobInformation, Collection<SlotInfoWithUtilization> freeSlots);
+
+    /**
+     * Assigns vertices to the given slots.
+     *
+     * @param jobInformation information about the job graph
+     * @param freeSlots currently free slots
+     * @param assignment information on how slots should be assigned to the slots
+     * @return parallelism of each vertex and mapping slots to vertices
+     */
+    DeclarativeScheduler.ParallelismAndResourceAssignments assignResources(
+            JobInformation jobInformation,
+            Collection<SlotInfoWithUtilization> freeSlots,
+            T assignment);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/SlotSharingAssignments.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/SlotSharingAssignments.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /** Mapping of slots to execution slot sharing groups. */
-class SlotSharingAssignments {
+class SlotSharingAssignments implements VertexAssignment {
 
     private final Collection<ExecutionSlotSharingGroupAndSlot> assignments;
 
@@ -37,6 +37,7 @@ class SlotSharingAssignments {
         return assignments;
     }
 
+    @Override
     public Map<JobVertexID, Integer> getMaxParallelismForVertices() {
         return assignments.stream()
                 .map(ExecutionSlotSharingGroupAndSlot::getExecutionSlotSharingGroup)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/VertexAssignment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/VertexAssignment.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative.allocator;
+
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import java.util.Map;
+
+/** Base container for assignments of vertices to slots. */
+public interface VertexAssignment {
+    Map<JobVertexID, Integer> getMaxParallelismForVertices();
+}


### PR DESCRIPTION
Splits SlotAllocator#determineParallelismAndAssignResources into 2 methods.

(There are a few naming issues that would need be solved; e.g. VertexAssignment doesn't quite make sense imo (because we assign things later...))