### PR TITLE
Add support for scaling up

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/JobInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/JobInformation.java
@@ -33,5 +33,7 @@ public interface JobInformation {
         JobVertexID getJobVertexID();
 
         int getParallelism();
+
+        SlotSharingGroup getSlotSharingGroup();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/MappingCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/MappingCalculator.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.runtime.scheduler.declarative.allocator;
 
-import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -29,10 +29,10 @@ interface MappingCalculator {
      * Attempts to create a mapping between vertices and slots.
      *
      * @param jobInformation information about the job graph
-     * @param freeSlots currently free slots
+     * @param slots slots to consider for determining the parallelism
      * @return mapping of slots and the vertices that should be deployed into them, if a mapping
      *     could be found
      */
     Optional<SlotSharingAssignments> determineParallelismAndAssignResources(
-            JobInformation jobInformation, Collection<SlotInfoWithUtilization> freeSlots);
+            JobInformation jobInformation, Collection<? extends SlotInfo> slots);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/RequirementsCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/RequirementsCalculator.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.runtime.scheduler.declarative.allocator;
 
-import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmaster.slotpool.ResourceCounter;
 
 /** Calculates resource requirements for a set of vertices. */
@@ -29,6 +28,5 @@ interface RequirementsCalculator {
      * @param vertices vertices to schedule
      * @return required resources
      */
-    // TODO: replace JobVertex with VertexInformation
-    ResourceCounter calculateRequiredSlots(Iterable<JobVertex> vertices);
+    ResourceCounter calculateRequiredSlots(Iterable<JobInformation.VertexInformation> vertices);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/SlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/SlotAllocator.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.runtime.scheduler.declarative.allocator;
 
+import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
 import org.apache.flink.runtime.scheduler.declarative.ParallelismAndResourceAssignments;
 
@@ -30,12 +31,12 @@ public interface SlotAllocator<T extends VertexAssignment> extends RequirementsC
      * Determines the parallelism at which the vertices could given the collection of slots.
      *
      * @param jobInformation information about the job graph
-     * @param freeSlots currently free slots
+     * @param slots Slots to consider for determining the parallelism
      * @return parallelism of each vertex along with implementation specific information, if the job
      *     could be run with the given slots
      */
     Optional<T> determineParallelism(
-            JobInformation jobInformation, Collection<SlotInfoWithUtilization> freeSlots);
+            JobInformation jobInformation, Collection<? extends SlotInfo> slots);
 
     /**
      * Assigns vertices to the given slots.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/SlotSharingMappingCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/SlotSharingMappingCalculator.java
@@ -18,7 +18,7 @@
 package org.apache.flink.runtime.scheduler.declarative.allocator;
 
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 
 import java.util.ArrayList;
@@ -37,12 +37,11 @@ class SlotSharingMappingCalculator implements MappingCalculator {
 
     @Override
     public Optional<SlotSharingAssignments> determineParallelismAndAssignResources(
-            JobInformation jobInformation, Collection<SlotInfoWithUtilization> freeSlots) {
-
+            JobInformation jobInformation, Collection<? extends SlotInfo> slots) {
         // TODO: This can waste slots if the max parallelism for slot sharing groups is not equal
         final int slotsPerSlotSharingGroup =
-                freeSlots.size() / jobInformation.getSlotSharingGroups().size();
-        final Iterator<SlotInfoWithUtilization> slotIterator = freeSlots.iterator();
+                slots.size() / jobInformation.getSlotSharingGroups().size();
+        final Iterator<? extends SlotInfo> slotIterator = slots.iterator();
 
         final Collection<ExecutionSlotSharingGroupAndSlot> assignments = new ArrayList<>();
 
@@ -58,7 +57,7 @@ class SlotSharingMappingCalculator implements MappingCalculator {
 
             for (ExecutionSlotSharingGroup executionSlotSharingGroup :
                     sharedSlotToVertexAssignment) {
-                final SlotInfoWithUtilization slotInfo = slotIterator.next();
+                final SlotInfo slotInfo = slotIterator.next();
 
                 assignments.add(
                         new ExecutionSlotSharingGroupAndSlot(executionSlotSharingGroup, slotInfo));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/SlotSharingRequirementsCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/SlotSharingRequirementsCalculator.java
@@ -19,7 +19,6 @@ package org.apache.flink.runtime.scheduler.declarative.allocator;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.SlotSharingGroupId;
-import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmaster.slotpool.ResourceCounter;
 
 import java.util.HashMap;
@@ -29,7 +28,8 @@ import java.util.Map;
 class SlotSharingRequirementsCalculator implements RequirementsCalculator {
 
     @Override
-    public ResourceCounter calculateRequiredSlots(Iterable<JobVertex> vertices) {
+    public ResourceCounter calculateRequiredSlots(
+            Iterable<JobInformation.VertexInformation> vertices) {
         int numTotalRequiredSlots = 0;
         for (Integer requiredSlots : getMaxParallelismForSlotSharingGroups(vertices).values()) {
             numTotalRequiredSlots += requiredSlots;
@@ -38,9 +38,9 @@ class SlotSharingRequirementsCalculator implements RequirementsCalculator {
     }
 
     private static Map<SlotSharingGroupId, Integer> getMaxParallelismForSlotSharingGroups(
-            Iterable<JobVertex> vertices) {
+            Iterable<JobInformation.VertexInformation> vertices) {
         final Map<SlotSharingGroupId, Integer> maxParallelismForSlotSharingGroups = new HashMap<>();
-        for (JobVertex vertex : vertices) {
+        for (JobInformation.VertexInformation vertex : vertices) {
             maxParallelismForSlotSharingGroups.compute(
                     vertex.getSlotSharingGroup().getSlotSharingGroupId(),
                     (slotSharingGroupId, currentMaxParallelism) ->

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/SlotSharingSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/SlotSharingSlotAllocator.java
@@ -21,7 +21,6 @@ import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
-import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
@@ -59,14 +58,15 @@ public class SlotSharingSlotAllocator implements SlotAllocator<SlotSharingAssign
     }
 
     @Override
-    public ResourceCounter calculateRequiredSlots(Iterable<JobVertex> vertices) {
+    public ResourceCounter calculateRequiredSlots(
+            Iterable<JobInformation.VertexInformation> vertices) {
         return requirementsCalculator.calculateRequiredSlots(vertices);
     }
 
     @Override
     public Optional<SlotSharingAssignments> determineParallelism(
-            JobInformation jobInformation, Collection<SlotInfoWithUtilization> freeSlots) {
-        return mappingCalculator.determineParallelismAndAssignResources(jobInformation, freeSlots);
+            JobInformation jobInformation, Collection<? extends SlotInfo> slots) {
+        return mappingCalculator.determineParallelismAndAssignResources(jobInformation, slots);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerClusterITCase.java
@@ -40,6 +40,7 @@ import org.junit.experimental.categories.Category;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
@@ -92,6 +93,36 @@ public class DeclarativeSchedulerClusterITCase extends TestLogger {
         final JobResult jobResult = resultFuture.join();
 
         assertTrue(jobResult.isSuccess());
+    }
+
+    @Test
+    public void testAutomaticScaleUp() throws Exception {
+        assumeTrue(ClusterOptions.isDeclarativeResourceManagementEnabled(configuration));
+
+        final MiniCluster miniCluster = miniClusterResource.getMiniCluster();
+        int targetInstanceCount = NUMBER_SLOTS_PER_TASK_MANAGER * (NUMBER_TASK_MANAGERS + 1);
+        final JobGraph jobGraph = createBlockingJobGraph(targetInstanceCount);
+
+        // initially only expect NUMBER_TASK_MANAGERS
+        OnceBlockingNoOpInvokable.resetFor(NUMBER_SLOTS_PER_TASK_MANAGER * NUMBER_TASK_MANAGERS);
+
+        log.info(
+                "Submitting job with parallelism of "
+                        + targetInstanceCount
+                        + ", to a cluster with only one TM.");
+        miniCluster.submitJob(jobGraph).join();
+
+        OnceBlockingNoOpInvokable.waitUntilOpsAreRunning();
+
+        log.info("Start additional TaskManager to scale up to the full parallelism.");
+        OnceBlockingNoOpInvokable.resetInstanceCount(); // we expect a restart
+        OnceBlockingNoOpInvokable.resetFor(targetInstanceCount);
+        miniCluster.startTaskManager();
+
+        log.info("Waiting until Invokable is running with higher parallelism");
+        OnceBlockingNoOpInvokable.waitUntilOpsAreRunning();
+
+        assertEquals(targetInstanceCount, OnceBlockingNoOpInvokable.getInstanceCount());
     }
 
     private JobGraph createBlockingJobGraph(int parallelism) throws IOException {


### PR DESCRIPTION
Based on and includes https://github.com/tillrohrmann/flink/pull/16.

This is really a minimal implementation for scaling up the job on additional slots.
For production use, I guess a configurable "cooldown" phase, conditions for scaling (at least n more slots, doubling of slots, ...) and more is needed.