### PR TITLE
Start OperatorCoordinators before deployment

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeSchedulerNG.java
@@ -872,6 +872,7 @@ public class DeclarativeSchedulerNG implements SchedulerNG {
         }
 
         private void deploy() {
+            operatorCoordinatorHandler.startAllOperatorCoordinators();
             for (ExecutionJobVertex executionJobVertex :
                     executionGraph.getVerticesTopologically()) {
                 for (ExecutionVertex executionVertex : executionJobVertex.getTaskVertices()) {
@@ -1049,7 +1050,7 @@ public class DeclarativeSchedulerNG implements SchedulerNG {
         private final ExecutionGraphHandler executionGraphHandler;
 
         // TODO: We still need to shut it down when we leave the StateWithExecutionGraph
-        private final OperatorCoordinatorHandler operatorCoordinatorHandler;
+        protected final OperatorCoordinatorHandler operatorCoordinatorHandler;
 
         protected StateWithExecutionGraph(ExecutionGraph executionGraph) {
             this.executionGraph = executionGraph;


### PR DESCRIPTION
Exposes the operator coordinator to `StateWithExecutionGraph` subclasses, and starts the coordinators before deploying the `ExecutionGraph` within `Executing`.
This doesn't quite reproduce the existing behavior because it starts the coordinators after the EG has switched to running, opposed to before (`SchedulerBase#startScheduling`).
I can't tell whether this is significant; it at least appears to be working.