### PR TITLE
Fix various issues

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/DeclarativeScheduler.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler.declarative;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
@@ -206,6 +207,12 @@ public class DeclarativeScheduler
                 new SlotSharingSlotAllocator(
                         declarativeSlotPool::reserveFreeSlot,
                         declarativeSlotPool::freeReservedSlot);
+
+        for (JobVertex vertex : jobGraph.getVertices()) {
+            if (vertex.getParallelism() == ExecutionConfig.PARALLELISM_DEFAULT) {
+                vertex.setParallelism(1);
+            }
+        }
 
         declarativeSlotPool.registerNewSlotsListener(this::newResourcesAvailable);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/WaitingForResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/WaitingForResources.java
@@ -100,6 +100,7 @@ class WaitingForResources implements State, ResourceConsumer {
 
             context.goToExecuting(executionGraph);
         } catch (Exception exception) {
+            logger.error("handling initialization failure", exception);
             context.goToFinished(context.getArchivedExecutionGraph(JobStatus.FAILED, exception));
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/SlotSharingMappingCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/allocator/SlotSharingMappingCalculator.java
@@ -41,8 +41,13 @@ class SlotSharingMappingCalculator implements MappingCalculator {
         // TODO: This can waste slots if the max parallelism for slot sharing groups is not equal
         final int slotsPerSlotSharingGroup =
                 slots.size() / jobInformation.getSlotSharingGroups().size();
-        final Iterator<? extends SlotInfo> slotIterator = slots.iterator();
 
+        if (slotsPerSlotSharingGroup == 0) {
+            // => less slots than slot-sharing groups
+            return Optional.empty();
+        }
+
+        final Iterator<? extends SlotInfo> slotIterator = slots.iterator();
         final Collection<ExecutionSlotSharingGroupAndSlot> assignments = new ArrayList<>();
 
         for (SlotSharingGroup slotSharingGroup : jobInformation.getSlotSharingGroups()) {


### PR DESCRIPTION
- set parallelism to 1 if it is set to `ExecutionConfig#DEFAULT_PARALLELISM` (-1)
  - this essentially moves some logic from ExecutionGraph#attachTopology into the JobMaster
  - the slotallocator doesn't handle this case, and imo it shouldn't be aware of it because it seems like an API thing
- ~~throw a JobNotFoundException if the JobID does not match when requesting KV state~~
  - ~~equivalent code path: `org.apache.flink.runtime.scheduler.KvStateHandler#notifyKvStateRegistered`~~
- fix issue where a non-empty Optional was returned if less slots than slotsharing groups are available