### PR TITLE
Fix FileSourceTextLinesITCase test failures

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Restarting.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Restarting.java
@@ -54,6 +54,11 @@ class Restarting extends StateWithExecutionGraph {
     }
 
     @Override
+    public JobStatus getJobStatus() {
+        return JobStatus.RESTARTING;
+    }
+
+    @Override
     public void cancel() {
         context.goToCanceling(
                 getExecutionGraph(), getExecutionGraphHandler(), getOperatorCoordinatorHandler());


### PR DESCRIPTION
- the job status is now pinned to RESTARTING while the scheduler is in the Restarting state
- 2 tests in the `FileSourceTextLinesITCase` now explicitly set a restart strategy
  - I don't really know what is going on here. The test is failing a taskexecutor and should inherently require restarts to be enabled in order to pass, which appears to be the case master. But for some reason with the declarative scheduler restarts are disabled by default.